### PR TITLE
Add ConnectionWithRetries, typedoc comments, README, privatize members

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# @atomiqlabs/chain-solana
+
+`@atomiqlabs/chain-solana` is the Solana integration package for the Atomiq protocol.
+
+Within the Atomiq stack, this library provides the Solana-side building blocks used for Bitcoin-aware swaps on Solana. It includes:
+
+- the `SolanaInitializer` used to register Solana support in the Atomiq SDK
+- the `SolanaChainInterface` used to talk to Solana RPCs
+- Solana BTC relay and swap program wrappers
+- signer and wallet helpers for Solana integrations
+- connection retry and chain event utilities
+
+This package is intended for direct protocol integrations and for higher-level Atomiq SDK layers that need Solana chain support.
+
+## Installation
+
+Install the package with its `@solana/web3.js` peer dependency:
+
+```bash
+npm install @atomiqlabs/chain-solana @solana/web3.js
+```
+
+## Node-only Classes
+
+The default package entrypoint stays browser-safe and does not export classes that depend on Node's `fs` module.
+
+Import backend-only utilities from the dedicated `node` subpath:
+
+```ts
+import {SolanaChainEvents} from "@atomiqlabs/chain-solana/node";
+```
+
+## Supported Chains
+
+This package exports a single Solana initializer:
+
+- Solana via `SolanaInitializer`
+
+Canonical deployments currently defined in this package:
+
+| Chain | Canonical deployments included |
+| --- | --- |
+| Solana | `MAINNET`, `TESTNET` |
+
+In this package, the selected Bitcoin network determines which canonical Solana program addresses are used by default. `BitcoinNetwork.TESTNET4` is not wired to a Solana deployment here yet.
+
+The Solana implementation doesn't support the UTXO-controlled vault (SPV vault) contract, hence it can only process legacy HTLC & PrTLC based swaps.
+
+## SDK Example
+
+Initialize the Atomiq SDK with Solana network support:
+
+```ts
+import {SolanaInitializer} from "@atomiqlabs/chain-solana";
+import {BitcoinNetwork, SwapperFactory, TypedSwapper} from "@atomiqlabs/sdk";
+
+// Define chains that you want to support here
+const chains = [SolanaInitializer] as const;
+type SupportedChains = typeof chains;
+
+const Factory = new SwapperFactory<SupportedChains>(chains);
+
+const swapper: TypedSwapper<SupportedChains> = Factory.newSwapper({
+  chains: {
+    SOLANA: {
+      rpcUrl: solanaRpc // You can also pass a web3.js Connection object here
+    }
+  },
+  bitcoinNetwork: BitcoinNetwork.MAINNET // or BitcoinNetwork.TESTNET
+});
+```
+
+If you use the lower-level initializer directly, you can also provide a custom storage backend for temporary Solana data accounts used when submitting large Bitcoin proof payloads.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,6 +3,7 @@ export { SolanaBtcStoredHeader } from "./solana/btcrelay/headers/SolanaBtcStored
 export * from "./solana/btcrelay/SolanaBtcRelay";
 export * from "./solana/chain/SolanaChainInterface";
 export * from "./solana/chain/modules/SolanaFees";
+export { ConnectionWithRetries } from "./solana/connection/ConnectionWithRetries";
 export * from "./solana/events/SolanaChainEventsBrowser";
 export * from "./solana/swaps/SolanaSwapProgram";
 export { SolanaSwapData } from "./solana/swaps/SolanaSwapData";

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,70 @@
+/**
+ * # @atomiqlabs/chain-solana
+ *
+ * `@atomiqlabs/chain-solana` is the Solana integration package for the Atomiq protocol.
+ *
+ * Within the Atomiq stack, this library provides the Solana-side building blocks used for Bitcoin-aware swaps on Solana. It includes:
+ *
+ * - the `SolanaInitializer` used to register Solana support in the Atomiq SDK
+ * - the `SolanaChainInterface` used to talk to Solana RPCs
+ * - Solana BTC relay and swap program wrappers
+ * - signer and wallet helpers for Solana integrations
+ * - connection retry and chain event utilities
+ *
+ * This package is intended for direct protocol integrations and for higher-level Atomiq SDK layers that need Solana chain support.
+ *
+ * ## Installation
+ *
+ * Install the package with its `@solana/web3.js` peer dependency:
+ *
+ * ```bash
+ * npm install @atomiqlabs/chain-solana @solana/web3.js
+ * ```
+ *
+ * ## Supported Chains
+ *
+ * This package exports a single Solana initializer:
+ *
+ * - Solana via `SolanaInitializer`
+ *
+ * Canonical deployments currently defined in this package:
+ *
+ * | Chain | Canonical deployments included |
+ * | --- | --- |
+ * | Solana | `MAINNET`, `TESTNET` |
+ *
+ * In this package, the selected Bitcoin network determines which canonical Solana program addresses are used by default. `BitcoinNetwork.TESTNET4` is not wired to a Solana deployment here yet.
+ *
+ * The Solana implementation doesn't support the UTXO-controlled vault (SPV vault) contract, hence it can only process legacy HTLC & PrTLC based swaps.
+ *
+ * ## SDK Example
+ *
+ * Initialize the Atomiq SDK with Solana network support:
+ *
+ * ```ts
+ * import {SolanaInitializer} from "@atomiqlabs/chain-solana";
+ * import {BitcoinNetwork, SwapperFactory, TypedSwapper} from "@atomiqlabs/sdk";
+ *
+ * // Define chains that you want to support here
+ * const chains = [SolanaInitializer] as const;
+ * type SupportedChains = typeof chains;
+ *
+ * const Factory = new SwapperFactory<SupportedChains>(chains);
+ *
+ * const swapper: TypedSwapper<SupportedChains> = Factory.newSwapper({
+ *   chains: {
+ *     SOLANA: {
+ *       rpcUrl: solanaRpc // You can also pass a web3.js Connection object here
+ *     }
+ *   },
+ *   bitcoinNetwork: BitcoinNetwork.MAINNET // or BitcoinNetwork.TESTNET
+ * });
+ * ```
+ *
+ * If you use the lower-level initializer directly, you can also provide a custom storage backend for temporary Solana data accounts used when submitting large Bitcoin proof payloads.
+ *
+ * @packageDocumentation
+ */
 export { SolanaBtcHeader } from "./solana/btcrelay/headers/SolanaBtcHeader";
 export { SolanaBtcStoredHeader } from "./solana/btcrelay/headers/SolanaBtcStoredHeader";
 export * from "./solana/btcrelay/SolanaBtcRelay";

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -70,6 +70,7 @@ export { SolanaBtcStoredHeader } from "./solana/btcrelay/headers/SolanaBtcStored
 export * from "./solana/btcrelay/SolanaBtcRelay";
 export * from "./solana/chain/SolanaChainInterface";
 export * from "./solana/chain/modules/SolanaFees";
+export { SolanaTx, SignedSolanaTx } from "./solana/chain/modules/SolanaTransactions";
 export { ConnectionWithRetries } from "./solana/connection/ConnectionWithRetries";
 export { SolanaChainEventsBrowser, SolanaEventListenerState } from "./solana/events/SolanaChainEventsBrowser";
 export * from "./solana/swaps/SolanaSwapProgram";

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,7 +4,7 @@ export * from "./solana/btcrelay/SolanaBtcRelay";
 export * from "./solana/chain/SolanaChainInterface";
 export * from "./solana/chain/modules/SolanaFees";
 export { ConnectionWithRetries } from "./solana/connection/ConnectionWithRetries";
-export * from "./solana/events/SolanaChainEventsBrowser";
+export { SolanaChainEventsBrowser, SolanaEventListenerState } from "./solana/events/SolanaChainEventsBrowser";
 export * from "./solana/swaps/SolanaSwapProgram";
 export { SolanaSwapData } from "./solana/swaps/SolanaSwapData";
 export * from "./solana/wallet/SolanaKeypairWallet";

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.SolanaSwapData = exports.SolanaBtcStoredHeader = exports.SolanaBtcHeader = void 0;
+exports.SolanaSwapData = exports.ConnectionWithRetries = exports.SolanaBtcStoredHeader = exports.SolanaBtcHeader = void 0;
 var SolanaBtcHeader_1 = require("./solana/btcrelay/headers/SolanaBtcHeader");
 Object.defineProperty(exports, "SolanaBtcHeader", { enumerable: true, get: function () { return SolanaBtcHeader_1.SolanaBtcHeader; } });
 var SolanaBtcStoredHeader_1 = require("./solana/btcrelay/headers/SolanaBtcStoredHeader");
@@ -22,6 +22,8 @@ Object.defineProperty(exports, "SolanaBtcStoredHeader", { enumerable: true, get:
 __exportStar(require("./solana/btcrelay/SolanaBtcRelay"), exports);
 __exportStar(require("./solana/chain/SolanaChainInterface"), exports);
 __exportStar(require("./solana/chain/modules/SolanaFees"), exports);
+var ConnectionWithRetries_1 = require("./solana/connection/ConnectionWithRetries");
+Object.defineProperty(exports, "ConnectionWithRetries", { enumerable: true, get: function () { return ConnectionWithRetries_1.ConnectionWithRetries; } });
 __exportStar(require("./solana/events/SolanaChainEventsBrowser"), exports);
 __exportStar(require("./solana/swaps/SolanaSwapProgram"), exports);
 var SolanaSwapData_1 = require("./solana/swaps/SolanaSwapData");

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,6 +15,73 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SolanaSwapData = exports.SolanaChainEventsBrowser = exports.ConnectionWithRetries = exports.SolanaBtcStoredHeader = exports.SolanaBtcHeader = void 0;
+/**
+ * # @atomiqlabs/chain-solana
+ *
+ * `@atomiqlabs/chain-solana` is the Solana integration package for the Atomiq protocol.
+ *
+ * Within the Atomiq stack, this library provides the Solana-side building blocks used for Bitcoin-aware swaps on Solana. It includes:
+ *
+ * - the `SolanaInitializer` used to register Solana support in the Atomiq SDK
+ * - the `SolanaChainInterface` used to talk to Solana RPCs
+ * - Solana BTC relay and swap program wrappers
+ * - signer and wallet helpers for Solana integrations
+ * - connection retry and chain event utilities
+ *
+ * This package is intended for direct protocol integrations and for higher-level Atomiq SDK layers that need Solana chain support.
+ *
+ * ## Installation
+ *
+ * Install the package with its `@solana/web3.js` peer dependency:
+ *
+ * ```bash
+ * npm install @atomiqlabs/chain-solana @solana/web3.js
+ * ```
+ *
+ * ## Supported Chains
+ *
+ * This package exports a single Solana initializer:
+ *
+ * - Solana via `SolanaInitializer`
+ *
+ * Canonical deployments currently defined in this package:
+ *
+ * | Chain | Canonical deployments included |
+ * | --- | --- |
+ * | Solana | `MAINNET`, `TESTNET` |
+ *
+ * In this package, the selected Bitcoin network determines which canonical Solana program addresses are used by default. `BitcoinNetwork.TESTNET4` is not wired to a Solana deployment here yet.
+ *
+ * The Solana implementation doesn't support the UTXO-controlled vault (SPV vault) contract, hence it can only process legacy HTLC & PrTLC based swaps.
+ *
+ * ## SDK Example
+ *
+ * Initialize the Atomiq SDK with Solana network support:
+ *
+ * ```ts
+ * import {SolanaInitializer} from "@atomiqlabs/chain-solana";
+ * import {BitcoinNetwork, SwapperFactory, TypedSwapper} from "@atomiqlabs/sdk";
+ *
+ * // Define chains that you want to support here
+ * const chains = [SolanaInitializer] as const;
+ * type SupportedChains = typeof chains;
+ *
+ * const Factory = new SwapperFactory<SupportedChains>(chains);
+ *
+ * const swapper: TypedSwapper<SupportedChains> = Factory.newSwapper({
+ *   chains: {
+ *     SOLANA: {
+ *       rpcUrl: solanaRpc // You can also pass a web3.js Connection object here
+ *     }
+ *   },
+ *   bitcoinNetwork: BitcoinNetwork.MAINNET // or BitcoinNetwork.TESTNET
+ * });
+ * ```
+ *
+ * If you use the lower-level initializer directly, you can also provide a custom storage backend for temporary Solana data accounts used when submitting large Bitcoin proof payloads.
+ *
+ * @packageDocumentation
+ */
 var SolanaBtcHeader_1 = require("./solana/btcrelay/headers/SolanaBtcHeader");
 Object.defineProperty(exports, "SolanaBtcHeader", { enumerable: true, get: function () { return SolanaBtcHeader_1.SolanaBtcHeader; } });
 var SolanaBtcStoredHeader_1 = require("./solana/btcrelay/headers/SolanaBtcStoredHeader");

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,7 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.SolanaSwapData = exports.ConnectionWithRetries = exports.SolanaBtcStoredHeader = exports.SolanaBtcHeader = void 0;
+exports.SolanaSwapData = exports.SolanaChainEventsBrowser = exports.ConnectionWithRetries = exports.SolanaBtcStoredHeader = exports.SolanaBtcHeader = void 0;
 var SolanaBtcHeader_1 = require("./solana/btcrelay/headers/SolanaBtcHeader");
 Object.defineProperty(exports, "SolanaBtcHeader", { enumerable: true, get: function () { return SolanaBtcHeader_1.SolanaBtcHeader; } });
 var SolanaBtcStoredHeader_1 = require("./solana/btcrelay/headers/SolanaBtcStoredHeader");
@@ -24,7 +24,8 @@ __exportStar(require("./solana/chain/SolanaChainInterface"), exports);
 __exportStar(require("./solana/chain/modules/SolanaFees"), exports);
 var ConnectionWithRetries_1 = require("./solana/connection/ConnectionWithRetries");
 Object.defineProperty(exports, "ConnectionWithRetries", { enumerable: true, get: function () { return ConnectionWithRetries_1.ConnectionWithRetries; } });
-__exportStar(require("./solana/events/SolanaChainEventsBrowser"), exports);
+var SolanaChainEventsBrowser_1 = require("./solana/events/SolanaChainEventsBrowser");
+Object.defineProperty(exports, "SolanaChainEventsBrowser", { enumerable: true, get: function () { return SolanaChainEventsBrowser_1.SolanaChainEventsBrowser; } });
 __exportStar(require("./solana/swaps/SolanaSwapProgram"), exports);
 var SolanaSwapData_1 = require("./solana/swaps/SolanaSwapData");
 Object.defineProperty(exports, "SolanaSwapData", { enumerable: true, get: function () { return SolanaSwapData_1.SolanaSwapData; } });

--- a/dist/node/index.d.ts
+++ b/dist/node/index.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Node.js-only entrypoint for filesystem-backed Solana helpers.
+ *
+ * Import from `@atomiqlabs/chain-solana/node` when you need runtime features
+ * that depend on Node's `fs` module.
+ *
+ * @packageDocumentation
+ */
+export { SolanaChainEvents } from "../solana/events/SolanaChainEvents";

--- a/dist/node/index.js
+++ b/dist/node/index.js
@@ -1,0 +1,13 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SolanaChainEvents = void 0;
+/**
+ * Node.js-only entrypoint for filesystem-backed Solana helpers.
+ *
+ * Import from `@atomiqlabs/chain-solana/node` when you need runtime features
+ * that depend on Node's `fs` module.
+ *
+ * @packageDocumentation
+ */
+var SolanaChainEvents_1 = require("../solana/events/SolanaChainEvents");
+Object.defineProperty(exports, "SolanaChainEvents", { enumerable: true, get: function () { return SolanaChainEvents_1.SolanaChainEvents; } });

--- a/dist/solana/SolanaInitializer.d.ts
+++ b/dist/solana/SolanaInitializer.d.ts
@@ -14,25 +14,55 @@ export type SolanaAssetsType = BaseTokenType<"WBTC" | "USDC" | "USDT" | "SOL" | 
  * @category Chain Interface
  */
 export type SolanaSwapperOptions = {
+    /**
+     * RPC url or {@link Connection} object to use for Solana network access
+     */
     rpcUrl: string | Connection;
+    /**
+     * Storage backend to use for storing ephemeral data submission accounts, i.e. accounts that are used
+     *  to submit large amount of data to an instruction that would otherwise be bigger than the transaction
+     *  size limit - used for submitting bitcoin transaction proofs for PrTLC swaps
+     */
     dataAccountStorage?: IStorageManager<StoredDataAccount>;
+    /**
+     * Retry policy to be used for Solana RPC calls and transaction submission
+     */
     retryPolicy?: SolanaRetryPolicy;
+    /**
+     * Optional Solana program address of the BTC Relay contract, uses the canonical deployment by default
+     */
     btcRelayContract?: string;
+    /**
+     * Optional Solana program address of the Swap contract, uses the canonical deployment by default
+     */
     swapContract?: string;
+    /**
+     * Solana fee API to use for fetching Solana network fees
+     */
     fees?: SolanaFees;
 };
 /**
  * Initialize Solana chain integration
+ *
+ * @param options Options for initializing the Solana chain
+ * @param bitcoinRpc Bitcoin RPC to use for bitcoin read access
+ * @param network Bitcoin network to use - determines Solana program addresses to use by default
+ * @param storageCtor Storage constructor used to create storage backend for ephemeral data submission accounts,
+ *  i.e. accounts that are used to submit large amount of data to an instruction that would otherwise be bigger
+ *  than the transaction size limit - used for submitting bitcoin transaction proofs for PrTLC swaps
+ *
  * @category Chain Interface
  */
 export declare function initializeSolana(options: SolanaSwapperOptions, bitcoinRpc: BitcoinRpc<any>, network: BitcoinNetwork, storageCtor: <T extends StorageObject>(name: string) => IStorageManager<T>): ChainData<SolanaChainType>;
 /**
  * Type definition for the Solana chain initializer
+ *
  * @category Chain Interface
  */
 export type SolanaInitializerType = ChainInitializer<SolanaSwapperOptions, SolanaChainType, SolanaAssetsType>;
 /**
- * Solana chain initializer instance
+ * Solana chain initializer instance, used in the SwapperFactory constructor in the SDK library
+ *
  * @category Chain Interface
  */
 export declare const SolanaInitializer: SolanaInitializerType;

--- a/dist/solana/SolanaInitializer.js
+++ b/dist/solana/SolanaInitializer.js
@@ -35,6 +35,14 @@ const SolanaAssets = {
 };
 /**
  * Initialize Solana chain integration
+ *
+ * @param options Options for initializing the Solana chain
+ * @param bitcoinRpc Bitcoin RPC to use for bitcoin read access
+ * @param network Bitcoin network to use - determines Solana program addresses to use by default
+ * @param storageCtor Storage constructor used to create storage backend for ephemeral data submission accounts,
+ *  i.e. accounts that are used to submit large amount of data to an instruction that would otherwise be bigger
+ *  than the transaction size limit - used for submitting bitcoin transaction proofs for PrTLC swaps
+ *
  * @category Chain Interface
  */
 function initializeSolana(options, bitcoinRpc, network, storageCtor) {
@@ -63,7 +71,8 @@ function initializeSolana(options, bitcoinRpc, network, storageCtor) {
 }
 exports.initializeSolana = initializeSolana;
 /**
- * Solana chain initializer instance
+ * Solana chain initializer instance, used in the SwapperFactory constructor in the SDK library
+ *
  * @category Chain Interface
  */
 exports.SolanaInitializer = {

--- a/dist/solana/btcrelay/SolanaBtcRelay.d.ts
+++ b/dist/solana/btcrelay/SolanaBtcRelay.d.ts
@@ -46,19 +46,19 @@ export declare class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBas
      * @param signer Signer paying and receiving rent refund
      * @param forkId Fork account identifier to close
      */
-    CloseForkAccount(signer: PublicKey, forkId: number): Promise<SolanaAction>;
+    private CloseForkAccount;
     /**
      * PDA of the relay main state account.
      */
-    BtcRelayMainState: PublicKey;
+    private readonly BtcRelayMainState;
     /**
      * PDA helper for per-header topic accounts.
      */
-    BtcRelayHeader: (hash: Buffer) => PublicKey;
+    private readonly BtcRelayHeader;
     /**
      * PDA helper for fork state accounts.
      */
-    BtcRelayFork: (forkId: number, pubkey: PublicKey) => PublicKey;
+    private readonly BtcRelayFork;
     /**
      * Bitcoin RPC client used for bitcoin chain lookups.
      */

--- a/dist/solana/btcrelay/SolanaBtcRelay.d.ts
+++ b/dist/solana/btcrelay/SolanaBtcRelay.d.ts
@@ -9,6 +9,8 @@ import { Buffer } from "buffer";
 import { SolanaSigner } from "../wallet/SolanaSigner";
 import { SolanaChainInterface } from "../chain/SolanaChainInterface";
 /**
+ * Solana BTC relay (bitcoin light client) program representation.
+ *
  * @category BTC Relay
  */
 export declare class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> implements BtcRelay<SolanaBtcStoredHeader, {
@@ -38,13 +40,40 @@ export declare class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBas
      * @param committedHeader
      */
     Verify(signer: PublicKey, reversedTxId: Buffer, confirmations: number, position: number, reversedMerkleProof: Buffer[], committedHeader: SolanaBtcStoredHeader): Promise<SolanaAction>;
+    /**
+     * Creates an action that closes a fork account and refunds rent to the signer.
+     *
+     * @param signer Signer paying and receiving rent refund
+     * @param forkId Fork account identifier to close
+     */
     CloseForkAccount(signer: PublicKey, forkId: number): Promise<SolanaAction>;
+    /**
+     * PDA of the relay main state account.
+     */
     BtcRelayMainState: PublicKey;
+    /**
+     * PDA helper for per-header topic accounts.
+     */
     BtcRelayHeader: (hash: Buffer) => PublicKey;
+    /**
+     * PDA helper for fork state accounts.
+     */
     BtcRelayFork: (forkId: number, pubkey: PublicKey) => PublicKey;
+    /**
+     * Bitcoin RPC client used for bitcoin chain lookups.
+     */
     bitcoinRpc: BitcoinRpc<B>;
+    /**
+     * @inheritDoc
+     */
     readonly maxHeadersPerTx: number;
+    /**
+     * @inheritDoc
+     */
     readonly maxForkHeadersPerTx: number;
+    /**
+     * @inheritDoc
+     */
     readonly maxShortForkHeadersPerTx: number;
     constructor(chainInterface: SolanaChainInterface, bitcoinRpc: BitcoinRpc<B>, programAddress?: string);
     /**
@@ -55,7 +84,7 @@ export declare class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBas
      */
     private getBlockCommitmentsSet;
     /**
-     * Computes subsequent commited headers as they will appear on the blockchain when transactions
+     * Computes subsequent committed headers as they will appear on the blockchain when transactions
      *  are submitted & confirmed
      *
      * @param initialStoredHeader

--- a/dist/solana/btcrelay/SolanaBtcRelay.d.ts
+++ b/dist/solana/btcrelay/SolanaBtcRelay.d.ts
@@ -61,8 +61,10 @@ export declare class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBas
     private readonly BtcRelayFork;
     /**
      * Bitcoin RPC client used for bitcoin chain lookups.
+     *
+     * @internal
      */
-    bitcoinRpc: BitcoinRpc<B>;
+    _bitcoinRpc: BitcoinRpc<B>;
     /**
      * @inheritDoc
      */
@@ -75,6 +77,11 @@ export declare class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBas
      * @inheritDoc
      */
     readonly maxShortForkHeadersPerTx: number;
+    /**
+     * @param chainInterface Underlying chain interface to use for the Solana chain operations
+     * @param bitcoinRpc Bitcoin RPC instance to use for read access to the bitcoin blockchain
+     * @param programAddress Optional Solana on-chain program address, defaults to the cannonical deployment
+     */
     constructor(chainInterface: SolanaChainInterface, bitcoinRpc: BitcoinRpc<B>, programAddress?: string);
     /**
      * Gets set of block commitments representing current main chain from the mainState

--- a/dist/solana/btcrelay/SolanaBtcRelay.js
+++ b/dist/solana/btcrelay/SolanaBtcRelay.js
@@ -24,6 +24,8 @@ function serializeBlockHeader(e) {
 }
 ;
 /**
+ * Solana BTC relay (bitcoin light client) program representation.
+ *
  * @category BTC Relay
  */
 class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
@@ -69,6 +71,12 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         })
             .instruction(), undefined, undefined, undefined, true);
     }
+    /**
+     * Creates an action that closes a fork account and refunds rent to the signer.
+     *
+     * @param signer Signer paying and receiving rent refund
+     * @param forkId Fork account identifier to close
+     */
     async CloseForkAccount(signer, forkId) {
         return new SolanaAction_1.SolanaAction(signer, this.Chain, await this.program.methods
             .closeForkAccount(new BN(forkId))
@@ -81,11 +89,29 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
     }
     constructor(chainInterface, bitcoinRpc, programAddress) {
         super(chainInterface, programIdl, programAddress);
+        /**
+         * PDA of the relay main state account.
+         */
         this.BtcRelayMainState = this.pda("state");
+        /**
+         * PDA helper for per-header topic accounts.
+         */
         this.BtcRelayHeader = this.pda("header", (hash) => [hash]);
+        /**
+         * PDA helper for fork state accounts.
+         */
         this.BtcRelayFork = this.pda("fork", (forkId, pubkey) => [new BN(forkId).toArrayLike(buffer_1.Buffer, "le", 8), pubkey.toBuffer()]);
+        /**
+         * @inheritDoc
+         */
         this.maxHeadersPerTx = 5;
+        /**
+         * @inheritDoc
+         */
         this.maxForkHeadersPerTx = 4;
+        /**
+         * @inheritDoc
+         */
         this.maxShortForkHeadersPerTx = 4;
         this.bitcoinRpc = bitcoinRpc;
     }
@@ -103,7 +129,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         return storedCommitments;
     }
     /**
-     * Computes subsequent commited headers as they will appear on the blockchain when transactions
+     * Computes subsequent committed headers as they will appear on the blockchain when transactions
      *  are submitted & confirmed
      *
      * @param initialStoredHeader

--- a/dist/solana/btcrelay/SolanaBtcRelay.js
+++ b/dist/solana/btcrelay/SolanaBtcRelay.js
@@ -10,6 +10,7 @@ const SolanaProgramBase_1 = require("../program/SolanaProgramBase");
 const SolanaAction_1 = require("../chain/SolanaAction");
 const buffer_1 = require("buffer");
 const BN = require("bn.js");
+const SolanaFees_1 = require("../chain/modules/SolanaFees");
 const MAX_CLOSE_IX_PER_TX = 10;
 function serializeBlockHeader(e) {
     return new SolanaBtcHeader_1.SolanaBtcHeader({
@@ -40,7 +41,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async Initialize(signer, header, epochStart, pastBlocksTimestamps) {
         const serializedBlock = serializeBlockHeader(header);
-        return new SolanaAction_1.SolanaAction(signer, this.Chain, await this.program.methods
+        return new SolanaAction_1.SolanaAction(signer, this._Chain, await this.program.methods
             .initialize(serializedBlock, header.getHeight(), header.getChainWork(), epochStart, pastBlocksTimestamps)
             .accounts({
             signer,
@@ -63,7 +64,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
      * @param committedHeader
      */
     async Verify(signer, reversedTxId, confirmations, position, reversedMerkleProof, committedHeader) {
-        return new SolanaAction_1.SolanaAction(signer, this.Chain, await this.program.methods
+        return new SolanaAction_1.SolanaAction(signer, this._Chain, await this.program.methods
             .verifyTransaction(reversedTxId, confirmations, position, reversedMerkleProof, committedHeader)
             .accounts({
             signer,
@@ -78,7 +79,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
      * @param forkId Fork account identifier to close
      */
     async CloseForkAccount(signer, forkId) {
-        return new SolanaAction_1.SolanaAction(signer, this.Chain, await this.program.methods
+        return new SolanaAction_1.SolanaAction(signer, this._Chain, await this.program.methods
             .closeForkAccount(new BN(forkId))
             .accounts({
             signer,
@@ -87,6 +88,11 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         })
             .instruction(), 20000);
     }
+    /**
+     * @param chainInterface Underlying chain interface to use for the Solana chain operations
+     * @param bitcoinRpc Bitcoin RPC instance to use for read access to the bitcoin blockchain
+     * @param programAddress Optional Solana on-chain program address, defaults to the cannonical deployment
+     */
     constructor(chainInterface, bitcoinRpc, programAddress) {
         super(chainInterface, programIdl, programAddress);
         /**
@@ -113,7 +119,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
          * @inheritDoc
          */
         this.maxShortForkHeadersPerTx = 4;
-        this.bitcoinRpc = bitcoinRpc;
+        this._bitcoinRpc = bitcoinRpc;
     }
     /**
      * Gets set of block commitments representing current main chain from the mainState
@@ -166,8 +172,8 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         }))
             .transaction();
         tx.feePayer = signer;
-        this.Chain.Fees.applyFeeRateBegin(tx, null, feeRate);
-        this.Chain.Fees.applyFeeRateEnd(tx, null, feeRate);
+        SolanaFees_1.SolanaFees.applyFeeRateBegin(tx, null, feeRate);
+        SolanaFees_1.SolanaFees.applyFeeRateEnd(tx, null, feeRate);
         const computedCommitedHeaders = this.computeCommitedHeaders(storedHeader, blockHeaderObj);
         const lastStoredHeader = computedCommitedHeaders[computedCommitedHeaders.length - 1];
         return {
@@ -205,7 +211,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         const storedCommitments = this.getBlockCommitmentsSet(mainState);
         const blockHashBuffer = buffer_1.Buffer.from(blockData.blockhash, 'hex').reverse();
         const topicKey = this.BtcRelayHeader(blockHashBuffer);
-        const data = await this.Events.findInEvents(topicKey, async (event) => {
+        const data = await this._Events.findInEvents(topicKey, async (event) => {
             if (event.name === "StoreFork" || event.name === "StoreHeader") {
                 const eventData = event.data;
                 const commitHash = buffer_1.Buffer.from(eventData.commitHash).toString("hex");
@@ -228,7 +234,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
     async retrieveLogByCommitHash(commitmentHashStr, blockData) {
         const blockHashBuffer = buffer_1.Buffer.from(blockData.blockhash, "hex").reverse();
         const topicKey = this.BtcRelayHeader(blockHashBuffer);
-        const data = await this.Events.findInEvents(topicKey, async (event) => {
+        const data = await this._Events.findInEvents(topicKey, async (event) => {
             if (event.name === "StoreFork" || event.name === "StoreHeader") {
                 const eventData = event.data;
                 const commitHash = buffer_1.Buffer.from(eventData.commitHash).toString("hex");
@@ -247,15 +253,15 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
     async retrieveLatestKnownBlockLog() {
         const mainState = await this.program.account.mainState.fetch(this.BtcRelayMainState);
         const storedCommitments = this.getBlockCommitmentsSet(mainState);
-        const data = await this.Events.findInEvents(this.program.programId, async (event) => {
+        const data = await this._Events.findInEvents(this.program.programId, async (event) => {
             if (event.name === "StoreFork" || event.name === "StoreHeader") {
                 const eventData = event.data;
                 const blockHashHex = buffer_1.Buffer.from(eventData.blockHash).reverse().toString("hex");
-                const isInMainChain = await this.bitcoinRpc.isInMainChain(blockHashHex).catch(() => false);
+                const isInMainChain = await this._bitcoinRpc.isInMainChain(blockHashHex).catch(() => false);
                 const commitHash = buffer_1.Buffer.from(eventData.commitHash).toString("hex");
                 //Check if this fork is part of main chain
                 if (isInMainChain && storedCommitments.has(commitHash)) {
-                    const blockHeader = await this.bitcoinRpc.getBlockHeader(blockHashHex);
+                    const blockHeader = await this._bitcoinRpc.getBlockHeader(blockHashHex);
                     if (blockHeader == null)
                         return null;
                     return {
@@ -370,7 +376,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         const mainState = await this.program.account.mainState.fetch(this.BtcRelayMainState);
         let forkId = mainState.forkCounter.toNumber();
         const txs = [];
-        let action = new SolanaAction_1.SolanaAction(signer.getPublicKey(), this.Chain);
+        let action = new SolanaAction_1.SolanaAction(signer.getPublicKey(), this._Chain);
         let lastCheckedId = lastSweepId;
         for (let i = lastSweepId == null ? 0 : lastSweepId + 1; i <= forkId; i++) {
             lastCheckedId = i;
@@ -382,14 +388,14 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
             action.add(await this.CloseForkAccount(signer.getPublicKey(), i));
             if (action.ixsLength() >= MAX_CLOSE_IX_PER_TX) {
                 await action.addToTxs(txs);
-                action = new SolanaAction_1.SolanaAction(signer.getPublicKey(), this.Chain);
+                action = new SolanaAction_1.SolanaAction(signer.getPublicKey(), this._Chain);
             }
         }
         if (action.ixsLength() >= MAX_CLOSE_IX_PER_TX) {
             await action.addToTxs(txs);
         }
         if (txs.length > 0) {
-            const signatures = await this.Chain.sendAndConfirm(signer, txs, true);
+            const signatures = await this._Chain.sendAndConfirm(signer, txs, true);
             this.logger.info("sweepForkData(): forks swept, signatures: " + signatures.join());
         }
         return lastCheckedId ?? null;
@@ -423,7 +429,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
      */
     getMainFeeRate(signer) {
         const _signer = signer == null ? null : new web3_js_1.PublicKey(signer);
-        return this.Chain.Fees.getFeeRate(_signer == null ? [this.BtcRelayMainState] : [
+        return this._Chain.Fees.getFeeRate(_signer == null ? [this.BtcRelayMainState] : [
             _signer,
             this.BtcRelayMainState
         ]);
@@ -433,7 +439,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
      */
     getForkFeeRate(signer, forkId) {
         const _signer = new web3_js_1.PublicKey(signer);
-        return this.Chain.Fees.getFeeRate([
+        return this._Chain.Fees.getFeeRate([
             _signer,
             this.BtcRelayMainState,
             this.BtcRelayFork(forkId, _signer)

--- a/dist/solana/btcrelay/SolanaBtcRelay.js
+++ b/dist/solana/btcrelay/SolanaBtcRelay.js
@@ -45,7 +45,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
             .accounts({
             signer,
             mainState: this.BtcRelayMainState,
-            headerTopic: this.BtcRelayHeader(serializedBlock.hash),
+            headerTopic: this.BtcRelayHeader(serializedBlock.getHash()),
             systemProgram: web3_js_1.SystemProgram.programId
         })
             .instruction(), 100000);
@@ -159,7 +159,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         const tx = await createTx(blockHeaderObj)
             .remainingAccounts(blockHeaderObj.map(e => {
             return {
-                pubkey: this.BtcRelayHeader(e.hash),
+                pubkey: this.BtcRelayHeader(e.getHash()),
                 isSigner: false,
                 isWritable: false
             };
@@ -238,7 +238,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         });
         if (data != null)
             this.logger.debug("retrieveLogByCommitHash(): block found," +
-                " commit hash: " + commitmentHashStr + " blockhash: " + blockData.blockhash + " height: " + data.blockheight);
+                " commit hash: " + commitmentHashStr + " blockhash: " + blockData.blockhash + " height: " + data.getBlockheight());
         return data;
     }
     /**
@@ -269,7 +269,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
         if (data != null)
             this.logger.debug("retrieveLatestKnownBlockLog(): block found," +
                 " commit hash: " + data.commitHash + " blockhash: " + data.resultBitcoinHeader.getHash() +
-                " height: " + data.resultStoredHeader.blockheight);
+                " height: " + data.resultStoredHeader.getBlockheight());
         return data;
     }
     /**
@@ -315,7 +315,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
             forkState: this.BtcRelayFork(forkId.toNumber(), _signer),
             systemProgram: web3_js_1.SystemProgram.programId,
         }));
-        if (result.forkId !== 0 && base_1.StatePredictorUtils.gtBuffer(buffer_1.Buffer.from(result.lastStoredHeader.chainWork), tipWork)) {
+        if (result.forkId !== 0 && base_1.StatePredictorUtils.gtBuffer(result.lastStoredHeader.getChainWork(), tipWork)) {
             //Fork's work is higher than main chain's work, this fork will become a main chain
             result.forkId = 0;
         }
@@ -337,7 +337,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
             forkState: this.BtcRelayFork(forkId, _signer),
             systemProgram: web3_js_1.SystemProgram.programId,
         }));
-        if (result.forkId !== 0 && base_1.StatePredictorUtils.gtBuffer(buffer_1.Buffer.from(result.lastStoredHeader.chainWork), tipWork)) {
+        if (result.forkId !== 0 && base_1.StatePredictorUtils.gtBuffer(result.lastStoredHeader.getChainWork(), tipWork)) {
             //Fork's work is higher than main chain's work, this fork will become a main chain
             result.forkId = 0;
         }
@@ -357,7 +357,7 @@ class SolanaBtcRelay extends SolanaProgramBase_1.SolanaProgramBase {
             signer: _signer,
             mainState: this.BtcRelayMainState
         }));
-        if (result.forkId !== 0 && base_1.StatePredictorUtils.gtBuffer(buffer_1.Buffer.from(result.lastStoredHeader.chainWork), tipWork)) {
+        if (result.forkId !== 0 && base_1.StatePredictorUtils.gtBuffer(result.lastStoredHeader.getChainWork(), tipWork)) {
             //Fork's work is higher than main chain's work, this fork will become a main chain
             result.forkId = 0;
         }

--- a/dist/solana/btcrelay/headers/SolanaBtcHeader.d.ts
+++ b/dist/solana/btcrelay/headers/SolanaBtcHeader.d.ts
@@ -20,31 +20,31 @@ export declare class SolanaBtcHeader implements BtcHeader {
     /**
      * Version field of the blockheader.
      */
-    version: number;
+    private readonly version;
     /**
      * Previous block hash in little-endian representation.
      */
-    reversedPrevBlockhash: number[];
+    private readonly reversedPrevBlockhash;
     /**
      * Merkle root in little-endian representation.
      */
-    merkleRoot: number[];
+    private readonly merkleRoot;
     /**
      * Block timestamp in UNIX seconds.
      */
-    timestamp: number;
+    private readonly timestamp;
     /**
      * Compact target (`nBits`) field.
      */
-    nbits: number;
+    private readonly nbits;
     /**
      * Nonce field.
      */
-    nonce: number;
+    private readonly nonce;
     /**
      * Reversed block hash bytes.
      */
-    hash: Buffer;
+    private readonly hash;
     /**
      * Constructs the bitcoin blockheader from Solana account/event data.
      *
@@ -75,5 +75,9 @@ export declare class SolanaBtcHeader implements BtcHeader {
      * @inheritDoc
      */
     getVersion(): number;
+    /**
+     * Returns block hash bytes in little-endian representation.
+     */
+    getHash(): Buffer;
 }
 export {};

--- a/dist/solana/btcrelay/headers/SolanaBtcHeader.d.ts
+++ b/dist/solana/btcrelay/headers/SolanaBtcHeader.d.ts
@@ -12,7 +12,7 @@ type SolanaBtcHeaderType = {
     hash: Buffer;
 };
 /**
- * Represents a bitcoin blockheader struct to be submitted to the Solana BTC relay program.
+ * Represents bitcoin blockheader data to be submitted to the Solana BTC relay program.
  *
  * @category BTC Relay
  */
@@ -46,9 +46,11 @@ export declare class SolanaBtcHeader implements BtcHeader {
      */
     private readonly hash;
     /**
-     * Constructs the bitcoin blockheader from Solana account/event data.
+     * Constructs the bitcoin blockheader
      *
-     * @param obj Decoded blockheader fields
+     * @param obj Blockheader fields
+     *
+     * @internal
      */
     constructor(obj: SolanaBtcHeaderType);
     /**

--- a/dist/solana/btcrelay/headers/SolanaBtcHeader.d.ts
+++ b/dist/solana/btcrelay/headers/SolanaBtcHeader.d.ts
@@ -12,22 +12,68 @@ type SolanaBtcHeaderType = {
     hash: Buffer;
 };
 /**
+ * Represents a bitcoin blockheader struct to be submitted to the Solana BTC relay program.
+ *
  * @category BTC Relay
  */
 export declare class SolanaBtcHeader implements BtcHeader {
+    /**
+     * Version field of the blockheader.
+     */
     version: number;
+    /**
+     * Previous block hash in little-endian representation.
+     */
     reversedPrevBlockhash: number[];
+    /**
+     * Merkle root in little-endian representation.
+     */
     merkleRoot: number[];
+    /**
+     * Block timestamp in UNIX seconds.
+     */
     timestamp: number;
+    /**
+     * Compact target (`nBits`) field.
+     */
     nbits: number;
+    /**
+     * Nonce field.
+     */
     nonce: number;
+    /**
+     * Reversed block hash bytes.
+     */
     hash: Buffer;
+    /**
+     * Constructs the bitcoin blockheader from Solana account/event data.
+     *
+     * @param obj Decoded blockheader fields
+     */
     constructor(obj: SolanaBtcHeaderType);
+    /**
+     * @inheritDoc
+     */
     getMerkleRoot(): Buffer;
+    /**
+     * @inheritDoc
+     */
     getNbits(): number;
+    /**
+     * @inheritDoc
+     */
     getNonce(): number;
+    /**
+     * @inheritDoc
+     */
     getReversedPrevBlockhash(): Buffer;
+    /**
+     * @inheritDoc
+     */
     getTimestamp(): number;
+    /**
+     * @inheritDoc
+     */
     getVersion(): number;
 }
 export {};

--- a/dist/solana/btcrelay/headers/SolanaBtcHeader.js
+++ b/dist/solana/btcrelay/headers/SolanaBtcHeader.js
@@ -3,15 +3,17 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.SolanaBtcHeader = void 0;
 const buffer_1 = require("buffer");
 /**
- * Represents a bitcoin blockheader struct to be submitted to the Solana BTC relay program.
+ * Represents bitcoin blockheader data to be submitted to the Solana BTC relay program.
  *
  * @category BTC Relay
  */
 class SolanaBtcHeader {
     /**
-     * Constructs the bitcoin blockheader from Solana account/event data.
+     * Constructs the bitcoin blockheader
      *
-     * @param obj Decoded blockheader fields
+     * @param obj Blockheader fields
+     *
+     * @internal
      */
     constructor(obj) {
         this.version = obj.version;

--- a/dist/solana/btcrelay/headers/SolanaBtcHeader.js
+++ b/dist/solana/btcrelay/headers/SolanaBtcHeader.js
@@ -3,9 +3,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.SolanaBtcHeader = void 0;
 const buffer_1 = require("buffer");
 /**
+ * Represents a bitcoin blockheader struct to be submitted to the Solana BTC relay program.
+ *
  * @category BTC Relay
  */
 class SolanaBtcHeader {
+    /**
+     * Constructs the bitcoin blockheader from Solana account/event data.
+     *
+     * @param obj Decoded blockheader fields
+     */
     constructor(obj) {
         this.version = obj.version;
         this.reversedPrevBlockhash = obj.reversedPrevBlockhash;
@@ -15,21 +22,39 @@ class SolanaBtcHeader {
         this.nonce = obj.nonce;
         this.hash = obj.hash;
     }
+    /**
+     * @inheritDoc
+     */
     getMerkleRoot() {
         return buffer_1.Buffer.from(this.merkleRoot);
     }
+    /**
+     * @inheritDoc
+     */
     getNbits() {
         return this.nbits;
     }
+    /**
+     * @inheritDoc
+     */
     getNonce() {
         return this.nonce;
     }
+    /**
+     * @inheritDoc
+     */
     getReversedPrevBlockhash() {
         return buffer_1.Buffer.from(this.reversedPrevBlockhash);
     }
+    /**
+     * @inheritDoc
+     */
     getTimestamp() {
         return this.timestamp;
     }
+    /**
+     * @inheritDoc
+     */
     getVersion() {
         return this.version;
     }

--- a/dist/solana/btcrelay/headers/SolanaBtcHeader.js
+++ b/dist/solana/btcrelay/headers/SolanaBtcHeader.js
@@ -58,5 +58,11 @@ class SolanaBtcHeader {
     getVersion() {
         return this.version;
     }
+    /**
+     * Returns block hash bytes in little-endian representation.
+     */
+    getHash() {
+        return this.hash;
+    }
 }
 exports.SolanaBtcHeader = SolanaBtcHeader;

--- a/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.d.ts
+++ b/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.d.ts
@@ -37,9 +37,11 @@ export declare class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcH
      */
     private readonly prevBlockTimestamps;
     /**
-     * Constructs the stored bitcoin blockheader from Solana account/event data.
+     * Constructs the stored bitcoin blockheader from Solana event data.
      *
      * @param obj Decoded stored-header fields
+     *
+     * @internal
      */
     constructor(obj: SolanaBtcStoredHeaderType);
     /**

--- a/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.d.ts
+++ b/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.d.ts
@@ -19,23 +19,23 @@ export declare class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcH
     /**
      * Total accumulated chainwork for this header.
      */
-    chainWork: number[];
+    private readonly chainWork;
     /**
      * Stored bitcoin blockheader.
      */
-    header: SolanaBtcHeader;
+    private readonly header;
     /**
      * Timestamp of the last difficulty adjustment.
      */
-    lastDiffAdjustment: number;
+    private readonly lastDiffAdjustment;
     /**
      * Blockheight of the stored header.
      */
-    blockheight: number;
+    private readonly blockheight;
     /**
      * Previous block timestamps tracked for median-time-past checks.
      */
-    prevBlockTimestamps: number[];
+    private readonly prevBlockTimestamps;
     /**
      * Constructs the stored bitcoin blockheader from Solana account/event data.
      *

--- a/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.d.ts
+++ b/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.d.ts
@@ -11,19 +11,56 @@ export type SolanaBtcStoredHeaderType = {
     prevBlockTimestamps: number[];
 };
 /**
+ * Represents a bitcoin blockheader that has already been stored and committed in the Solana BTC relay program.
+ *
  * @category BTC Relay
  */
 export declare class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
+    /**
+     * Total accumulated chainwork for this header.
+     */
     chainWork: number[];
+    /**
+     * Stored bitcoin blockheader.
+     */
     header: SolanaBtcHeader;
+    /**
+     * Timestamp of the last difficulty adjustment.
+     */
     lastDiffAdjustment: number;
+    /**
+     * Blockheight of the stored header.
+     */
     blockheight: number;
+    /**
+     * Previous block timestamps tracked for median-time-past checks.
+     */
     prevBlockTimestamps: number[];
+    /**
+     * Constructs the stored bitcoin blockheader from Solana account/event data.
+     *
+     * @param obj Decoded stored-header fields
+     */
     constructor(obj: SolanaBtcStoredHeaderType);
+    /**
+     * @inheritDoc
+     */
     getBlockheight(): number;
+    /**
+     * @inheritDoc
+     */
     getChainWork(): Buffer;
+    /**
+     * @inheritDoc
+     */
     getHeader(): SolanaBtcHeader;
+    /**
+     * @inheritDoc
+     */
     getLastDiffAdjustment(): number;
+    /**
+     * @inheritDoc
+     */
     getPrevBlockTimestamps(): number[];
     /**
      * Computes prevBlockTimestamps for a next block, shifting the old block timestamps to the left & appending
@@ -46,5 +83,8 @@ export declare class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcH
      * @private
      */
     private computeNextLastDiffAdjustment;
+    /**
+     * @inheritDoc
+     */
     computeNext(header: SolanaBtcHeader): SolanaBtcStoredHeader;
 }

--- a/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.js
+++ b/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.js
@@ -62,7 +62,7 @@ class SolanaBtcStoredHeader {
         for (let i = 1; i < 10; i++) {
             prevBlockTimestamps[i - 1] = prevBlockTimestamps[i];
         }
-        prevBlockTimestamps[9] = this.header.timestamp;
+        prevBlockTimestamps[9] = this.header.getTimestamp();
         return prevBlockTimestamps;
     }
     /**
@@ -95,10 +95,10 @@ class SolanaBtcStoredHeader {
      */
     computeNext(header) {
         return new SolanaBtcStoredHeader({
-            chainWork: this.computeNextChainWork(header.nbits),
+            chainWork: this.computeNextChainWork(header.getNbits()),
             prevBlockTimestamps: this.computeNextBlockTimestamps(),
             blockheight: this.blockheight + 1,
-            lastDiffAdjustment: this.computeNextLastDiffAdjustment(header.timestamp),
+            lastDiffAdjustment: this.computeNextLastDiffAdjustment(header.getTimestamp()),
             header
         });
     }

--- a/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.js
+++ b/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.js
@@ -10,9 +10,11 @@ const buffer_1 = require("buffer");
  */
 class SolanaBtcStoredHeader {
     /**
-     * Constructs the stored bitcoin blockheader from Solana account/event data.
+     * Constructs the stored bitcoin blockheader from Solana event data.
      *
      * @param obj Decoded stored-header fields
+     *
+     * @internal
      */
     constructor(obj) {
         this.chainWork = obj.chainWork;

--- a/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.js
+++ b/dist/solana/btcrelay/headers/SolanaBtcStoredHeader.js
@@ -4,9 +4,16 @@ exports.SolanaBtcStoredHeader = void 0;
 const base_1 = require("@atomiqlabs/base");
 const buffer_1 = require("buffer");
 /**
+ * Represents a bitcoin blockheader that has already been stored and committed in the Solana BTC relay program.
+ *
  * @category BTC Relay
  */
 class SolanaBtcStoredHeader {
+    /**
+     * Constructs the stored bitcoin blockheader from Solana account/event data.
+     *
+     * @param obj Decoded stored-header fields
+     */
     constructor(obj) {
         this.chainWork = obj.chainWork;
         this.header = obj.header;
@@ -14,18 +21,33 @@ class SolanaBtcStoredHeader {
         this.blockheight = obj.blockheight;
         this.prevBlockTimestamps = obj.prevBlockTimestamps;
     }
+    /**
+     * @inheritDoc
+     */
     getBlockheight() {
         return this.blockheight;
     }
+    /**
+     * @inheritDoc
+     */
     getChainWork() {
         return buffer_1.Buffer.from(this.chainWork);
     }
+    /**
+     * @inheritDoc
+     */
     getHeader() {
         return this.header;
     }
+    /**
+     * @inheritDoc
+     */
     getLastDiffAdjustment() {
         return this.lastDiffAdjustment;
     }
+    /**
+     * @inheritDoc
+     */
     getPrevBlockTimestamps() {
         return this.prevBlockTimestamps;
     }
@@ -68,6 +90,9 @@ class SolanaBtcStoredHeader {
         }
         return lastDiffAdjustment;
     }
+    /**
+     * @inheritDoc
+     */
     computeNext(header) {
         return new SolanaBtcStoredHeader({
             chainWork: this.computeNextChainWork(header.nbits),

--- a/dist/solana/chain/SolanaAction.js
+++ b/dist/solana/chain/SolanaAction.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SolanaAction = void 0;
 const web3_js_1 = require("@solana/web3.js");
+const SolanaFees_1 = require("./modules/SolanaFees");
 class SolanaAction {
     constructor(mainSigner, root, instructions = [], computeBudget = 0, feeRate, signers, firstIxBeforeComputeBudget) {
         this.firstIxBeforeComputeBudget = false;
@@ -64,9 +65,9 @@ class SolanaAction {
             tx.add(this.instructions[0]);
             instructions = this.instructions.slice(1);
         }
-        this.root.Fees.applyFeeRateBegin(tx, this.computeBudget, feeRate);
+        SolanaFees_1.SolanaFees.applyFeeRateBegin(tx, this.computeBudget, feeRate);
         instructions.forEach(ix => tx.add(ix));
-        this.root.Fees.applyFeeRateEnd(tx, this.computeBudget, feeRate);
+        SolanaFees_1.SolanaFees.applyFeeRateEnd(tx, this.computeBudget, feeRate);
         if (block != null) {
             tx.recentBlockhash = block.blockhash;
             tx.lastValidBlockHeight = block.blockHeight + this.root.TX_SLOT_VALIDITY;

--- a/dist/solana/chain/SolanaAction.js
+++ b/dist/solana/chain/SolanaAction.js
@@ -70,7 +70,7 @@ class SolanaAction {
         SolanaFees_1.SolanaFees.applyFeeRateEnd(tx, this.computeBudget, feeRate);
         if (block != null) {
             tx.recentBlockhash = block.blockhash;
-            tx.lastValidBlockHeight = block.blockHeight + this.root.TX_SLOT_VALIDITY;
+            tx.lastValidBlockHeight = block.blockHeight + this.root._TX_SLOT_VALIDITY;
         }
         return {
             tx,

--- a/dist/solana/chain/SolanaChainInterface.d.ts
+++ b/dist/solana/chain/SolanaChainInterface.d.ts
@@ -17,9 +17,21 @@ import { Wallet } from "@coral-xyz/anchor/dist/cjs/provider";
  * @category Chain Interface
  */
 export type SolanaRetryPolicy = {
+    /**
+     * Maximum retries to be attempted
+     */
     maxRetries?: number;
+    /**
+     * Default delay between retries
+     */
     delay?: number;
+    /**
+     * Whether the delays should scale exponentially, i.e. 1 second, 2 seconds, 4 seconds, 8 seconds
+     */
     exponential?: boolean;
+    /**
+     * Interval between re-sending Solana transaction to the RPC
+     */
     transactionResendInterval?: number;
 };
 /**

--- a/dist/solana/chain/SolanaChainInterface.d.ts
+++ b/dist/solana/chain/SolanaChainInterface.d.ts
@@ -45,20 +45,24 @@ export declare class SolanaChainInterface implements ChainInterface<SolanaTx, Si
     readonly chainId = "SOLANA";
     /**
      * Average Solana slot time in milliseconds.
+     * @internal
      */
-    readonly SLOT_TIME = 400;
+    readonly _SLOT_TIME = 400;
     /**
      * Approximate number of recent slots for which a transaction remains valid.
+     * @internal
      */
-    readonly TX_SLOT_VALIDITY = 151;
+    readonly _TX_SLOT_VALIDITY = 151;
     /**
      * Underlying Solana web3.js connection.
+     * @internal
      */
-    readonly connection: Connection;
+    readonly _connection: Connection;
     /**
      * Retry policy used by chain modules.
+     * @internal
      */
-    readonly retryPolicy?: SolanaRetryPolicy;
+    readonly _retryPolicy?: SolanaRetryPolicy;
     /**
      * Block-related read module.
      */
@@ -87,6 +91,9 @@ export declare class SolanaChainInterface implements ChainInterface<SolanaTx, Si
      * Event/log scanning module.
      */
     readonly Events: SolanaEvents;
+    /**
+     * @internal
+     */
     protected readonly logger: {
         debug: (msg: string, ...args: any[]) => false | void;
         info: (msg: string, ...args: any[]) => false | void;

--- a/dist/solana/chain/SolanaChainInterface.d.ts
+++ b/dist/solana/chain/SolanaChainInterface.d.ts
@@ -27,17 +27,53 @@ export type SolanaRetryPolicy = {
  * @category Chain Interface
  */
 export declare class SolanaChainInterface implements ChainInterface<SolanaTx, SignedSolanaTx, SolanaSigner, "SOLANA", Wallet> {
+    /**
+     * @inheritDoc
+     */
     readonly chainId = "SOLANA";
+    /**
+     * Average Solana slot time in milliseconds.
+     */
     readonly SLOT_TIME = 400;
+    /**
+     * Approximate number of recent slots for which a transaction remains valid.
+     */
     readonly TX_SLOT_VALIDITY = 151;
+    /**
+     * Underlying Solana web3.js connection.
+     */
     readonly connection: Connection;
+    /**
+     * Retry policy used by chain modules.
+     */
     readonly retryPolicy?: SolanaRetryPolicy;
+    /**
+     * Block-related read module.
+     */
     readonly Blocks: SolanaBlocks;
+    /**
+     * Fee estimation and fee-rate module.
+     */
     Fees: SolanaFees;
+    /**
+     * Slot-related read module.
+     */
     readonly Slots: SolanaSlots;
+    /**
+     * Token operations module.
+     */
     readonly Tokens: SolanaTokens;
+    /**
+     * Transaction send/confirm/serialization module.
+     */
     readonly Transactions: SolanaTransactions;
+    /**
+     * Signature utilities module.
+     */
     readonly Signatures: SolanaSignatures;
+    /**
+     * Event/log scanning module.
+     */
     readonly Events: SolanaEvents;
     protected readonly logger: {
         debug: (msg: string, ...args: any[]) => false | void;
@@ -125,7 +161,17 @@ export declare class SolanaChainInterface implements ChainInterface<SolanaTx, Si
      * @inheritDoc
      */
     offBeforeTxSigned(callback: (tx: SolanaTx) => Promise<void>): boolean;
+    /**
+     * Registers a low-level transaction sender override hook.
+     *
+     * @param callback Callback used for raw transaction publishing
+     */
     onSendTransaction(callback: (tx: Buffer, options?: SendOptions) => Promise<string>): void;
+    /**
+     * Unregisters a previously registered transaction sender override hook.
+     *
+     * @param callback Previously registered callback
+     */
     offSendTransaction(callback: (tx: Buffer, options?: SendOptions) => Promise<string>): boolean;
     /**
      * @inheritDoc

--- a/dist/solana/chain/SolanaChainInterface.js
+++ b/dist/solana/chain/SolanaChainInterface.js
@@ -25,15 +25,20 @@ class SolanaChainInterface {
         this.chainId = "SOLANA";
         /**
          * Average Solana slot time in milliseconds.
+         * @internal
          */
-        this.SLOT_TIME = 400;
+        this._SLOT_TIME = 400;
         /**
          * Approximate number of recent slots for which a transaction remains valid.
+         * @internal
          */
-        this.TX_SLOT_VALIDITY = 151;
+        this._TX_SLOT_VALIDITY = 151;
+        /**
+         * @internal
+         */
         this.logger = (0, Utils_1.getLogger)(this.constructor.name + ": ");
-        this.connection = connection;
-        this.retryPolicy = retryPolicy;
+        this._connection = connection;
+        this._retryPolicy = retryPolicy;
         this.Blocks = new SolanaBlocks_1.SolanaBlocks(this);
         this.Fees = solanaFeeEstimator;
         this.Slots = new SolanaSlots_1.SolanaSlots(this);

--- a/dist/solana/chain/SolanaChainInterface.js
+++ b/dist/solana/chain/SolanaChainInterface.js
@@ -19,8 +19,17 @@ const SolanaKeypairWallet_1 = require("../wallet/SolanaKeypairWallet");
  */
 class SolanaChainInterface {
     constructor(connection, retryPolicy, solanaFeeEstimator = new SolanaFees_1.SolanaFees(connection)) {
+        /**
+         * @inheritDoc
+         */
         this.chainId = "SOLANA";
+        /**
+         * Average Solana slot time in milliseconds.
+         */
         this.SLOT_TIME = 400;
+        /**
+         * Approximate number of recent slots for which a transaction remains valid.
+         */
         this.TX_SLOT_VALIDITY = 151;
         this.logger = (0, Utils_1.getLogger)(this.constructor.name + ": ");
         this.connection = connection;
@@ -165,9 +174,19 @@ class SolanaChainInterface {
     offBeforeTxSigned(callback) {
         return this.Transactions.offBeforeTxSigned(callback);
     }
+    /**
+     * Registers a low-level transaction sender override hook.
+     *
+     * @param callback Callback used for raw transaction publishing
+     */
     onSendTransaction(callback) {
         this.Transactions.onSendTransaction(callback);
     }
+    /**
+     * Unregisters a previously registered transaction sender override hook.
+     *
+     * @param callback Previously registered callback
+     */
     offSendTransaction(callback) {
         return this.Transactions.offSendTransaction(callback);
     }

--- a/dist/solana/chain/SolanaModule.js
+++ b/dist/solana/chain/SolanaModule.js
@@ -5,8 +5,8 @@ const Utils_1 = require("../../utils/Utils");
 class SolanaModule {
     constructor(root) {
         this.logger = (0, Utils_1.getLogger)(this.constructor.name + ": ");
-        this.connection = root.connection;
-        this.retryPolicy = root.retryPolicy;
+        this.connection = root._connection;
+        this.retryPolicy = root._retryPolicy;
         this.root = root;
     }
 }

--- a/dist/solana/chain/modules/SolanaFees.d.ts
+++ b/dist/solana/chain/modules/SolanaFees.d.ts
@@ -1,11 +1,21 @@
 /// <reference types="node" />
 /// <reference types="node" />
 import { Connection, PublicKey, SendOptions, Transaction } from "@solana/web3.js";
+/**
+ * Bribe endpoint configuration used for Jito-compatible fee payment flows.
+ *
+ * @category Chain Interface
+ */
 export type FeeBribeData = {
     address: string;
     endpoint: string;
     getBribeFee?: (original: bigint) => bigint;
 };
+/**
+ * Fee estimation service for Solana chains.
+ *
+ * @category Chain Interface
+ */
 export declare class SolanaFees {
     private readonly connection;
     private readonly maxFeeMicroLamports;

--- a/dist/solana/chain/modules/SolanaFees.d.ts
+++ b/dist/solana/chain/modules/SolanaFees.d.ts
@@ -2,17 +2,29 @@
 /// <reference types="node" />
 import { Connection, PublicKey, SendOptions, Transaction } from "@solana/web3.js";
 /**
- * Bribe endpoint configuration used for Jito-compatible fee payment flows.
+ * Bribe configuration used for Jito-like tips that handled outside of native Solana network fees
  *
  * @category Chain Interface
  */
 export type FeeBribeData = {
+    /**
+     * Address to send the bribe to (e.g. Jito tip)
+     */
     address: string;
+    /**
+     * HTTP endpoint to send the transaction to instead of the RPC, e.g. a Jito endpoint
+     */
     endpoint: string;
+    /**
+     * An optional function for overriding the bribe to be sent to the specified address for the tx
+     */
     getBribeFee?: (original: bigint) => bigint;
 };
 /**
- * Fee estimation service for Solana chains.
+ * Fee estimation service for the Solana network. Uses client-side fee estimation algorithm by default, which
+ *  fetches a bunch (default 8) random blocks in the past period (default 150) and computes the average fee. It
+ *  automatically detects whether the underlying RPC endpoint is a Helius one which features the `getPriorityFeeEstimate`
+ *  endpoint, and if available uses that one.
  *
  * @category Chain Interface
  */
@@ -28,6 +40,21 @@ export declare class SolanaFees {
     private readonly getStaticFee?;
     private readonly logger;
     private blockFeeCache?;
+    /**
+     * @param connection Underlying Solana network connection to use for read access to Solana
+     * @param maxFeeMicroLamports Maximum allowed fee in microLamports/CU (1/1,000,000 of a lamport per compute unit)
+     * @param numSamples Number of samples to use when estimating the global fee on the client-side, this many blocks are
+     *  sampled from the last `period` blocks to estimate an average fee rate
+     * @param period Period of past blocks to sample random blocks from when estimating the global fee on the client-side
+     * @param useHeliusApi Whether to use the helius API or not, default to `"auto"`, which automatically detects if the
+     *  underlying RPC supports Helius's `getPriorityFeeEstimate` RPC call
+     * @param heliusFeeLevel Fee level to use when fetching the fee rate from Helius's `getPriorityFeeEstimate` RPC endpoint,
+     *  for the meaning of the different levels refer to https://www.helius.dev/docs/priority-fee-api#priority-levels-explained
+     * @param getStaticFee Optional function for adding a base fee to transactions (this function returns the base fee
+     *  in lamports to be added to the transaction) - this fee doesn't scale with CUs of the transaction and is instead
+     *  applied as-is
+     * @param bribeData Bribe fee configuration (used for e.g. Jito tips)
+     */
     constructor(connection: Connection, maxFeeMicroLamports?: number, numSamples?: number, period?: number, useHeliusApi?: "yes" | "no" | "auto", heliusFeeLevel?: "min" | "low" | "medium" | "high" | "veryHigh" | "unsafeMax", getStaticFee?: (feeRate: bigint) => bigint, bribeData?: FeeBribeData);
     /**
      * Returns solana block with transactionDetails="signatures"
@@ -104,28 +131,58 @@ export declare class SolanaFees {
      */
     getPriorityFee(computeUnits: number, feeRate: string, includeStaticFee?: boolean): bigint;
     /**
-     * Applies fee rate to a transaction at the beginning of the transaction (has to be called after
-     *  feePayer is set for the tx), specifically adds the setComputeUnitLimit & setComputeUnitPrice instruction
+     * Applies fee rate to a transaction, should be called before adding instructions to the transaction, specifically
+     *  it adds the setComputeUnitLimit & setComputeUnitPrice instruction.
+     *
+     * @example
+     * ```typescript
+     * const feeRate = solanaFees.getFeeRate([...writeableAccounts]);
+     * const tx = new Transaction();
+     * //Apply the fee rate part at the beginning of the transaction (specifically setComputeUnitLimit & setComputeUnitPrice)
+     * SolanaFees.applyFeeRateBegin(tx, feeRate);
+     * //Add instructions here
+     * tx.add(instruction1);
+     * tx.add(instruction2);
+     * //Set the fee payer
+     * tx.feePayer = feePayerPublicKey;
+     * //Apply the fee rate part at the end of the transaction (specifically the transfer to the bribe account, e.g. Jito tip)
+     * SolanaFees.applyFeeRateEnd(tx, feeRate);
+     * ```
      *
      * @param tx
      * @param computeBudget
      * @param feeRate
      */
-    applyFeeRateBegin(tx: Transaction, computeBudget: number | null, feeRate: string): void;
+    static applyFeeRateBegin(tx: Transaction, computeBudget: number | null, feeRate: string): void;
     /**
-     * Applies fee rate to the end of the transaction (has to be called after feePayer is set for the tx),
-     *  specifically adds the bribe SystemProgram.transfer instruction
+     * Applies fee rate to a transaction, should be called after adding instructions to the transaction, specifically
+     *  it adds the adds the bribe SystemProgram.transfer instruction.
+     *
+     * @example
+     * ```typescript
+     * const feeRate = solanaFees.getFeeRate([...writeableAccounts]);
+     * const tx = new Transaction();
+     * //Apply the fee rate part at the beginning of the transaction (specifically setComputeUnitLimit & setComputeUnitPrice)
+     * SolanaFees.applyFeeRateBegin(tx, feeRate);
+     * //Add instructions here
+     * tx.add(instruction1);
+     * tx.add(instruction2);
+     * //Set the fee payer
+     * tx.feePayer = feePayerPublicKey;
+     * //Apply the fee rate part at the end of the transaction (specifically the transfer to the bribe account, e.g. Jito tip)
+     * SolanaFees.applyFeeRateEnd(tx, feeRate);
+     * ```
      *
      * @param tx
      * @param computeBudget
      * @param feeRate
      */
-    applyFeeRateEnd(tx: Transaction, computeBudget: number | null, feeRate: string): void;
+    static applyFeeRateEnd(tx: Transaction, computeBudget: number | null, feeRate: string): void;
     /**
      * Checks if the transaction should be submitted over Jito and if yes submits it
      *
-     * @param tx
-     * @param options
+     * @param tx Raw signed transaction to be attempted to be sent over Jito
+     * @param options Send options for the sendTransaction RPC call
      * @returns {Promise<string | null>} null if the transaction was not sent over Jito, tx signature when tx was sent over Jito
      */
     submitTx(tx: Buffer, options?: SendOptions): Promise<string | null>;

--- a/dist/solana/chain/modules/SolanaFees.js
+++ b/dist/solana/chain/modules/SolanaFees.js
@@ -5,11 +5,29 @@ const web3_js_1 = require("@solana/web3.js");
 const Utils_1 = require("../../../utils/Utils");
 const MAX_FEE_AGE = 5000;
 /**
- * Fee estimation service for Solana chains.
+ * Fee estimation service for the Solana network. Uses client-side fee estimation algorithm by default, which
+ *  fetches a bunch (default 8) random blocks in the past period (default 150) and computes the average fee. It
+ *  automatically detects whether the underlying RPC endpoint is a Helius one which features the `getPriorityFeeEstimate`
+ *  endpoint, and if available uses that one.
  *
  * @category Chain Interface
  */
 class SolanaFees {
+    /**
+     * @param connection Underlying Solana network connection to use for read access to Solana
+     * @param maxFeeMicroLamports Maximum allowed fee in microLamports/CU (1/1,000,000 of a lamport per compute unit)
+     * @param numSamples Number of samples to use when estimating the global fee on the client-side, this many blocks are
+     *  sampled from the last `period` blocks to estimate an average fee rate
+     * @param period Period of past blocks to sample random blocks from when estimating the global fee on the client-side
+     * @param useHeliusApi Whether to use the helius API or not, default to `"auto"`, which automatically detects if the
+     *  underlying RPC supports Helius's `getPriorityFeeEstimate` RPC call
+     * @param heliusFeeLevel Fee level to use when fetching the fee rate from Helius's `getPriorityFeeEstimate` RPC endpoint,
+     *  for the meaning of the different levels refer to https://www.helius.dev/docs/priority-fee-api#priority-levels-explained
+     * @param getStaticFee Optional function for adding a base fee to transactions (this function returns the base fee
+     *  in lamports to be added to the transaction) - this fee doesn't scale with CUs of the transaction and is instead
+     *  applied as-is
+     * @param bribeData Bribe fee configuration (used for e.g. Jito tips)
+     */
     constructor(connection, maxFeeMicroLamports = 250000, numSamples = 8, period = 150, useHeliusApi = "auto", heliusFeeLevel = "veryHigh", getStaticFee, bribeData) {
         this.heliusApiSupported = true;
         this.logger = (0, Utils_1.getLogger)("SolanaFees: ");
@@ -300,14 +318,29 @@ class SolanaFees {
         return staticFee + (cuPrice * BigInt(computeUnits) / 1000000n);
     }
     /**
-     * Applies fee rate to a transaction at the beginning of the transaction (has to be called after
-     *  feePayer is set for the tx), specifically adds the setComputeUnitLimit & setComputeUnitPrice instruction
+     * Applies fee rate to a transaction, should be called before adding instructions to the transaction, specifically
+     *  it adds the setComputeUnitLimit & setComputeUnitPrice instruction.
+     *
+     * @example
+     * ```typescript
+     * const feeRate = solanaFees.getFeeRate([...writeableAccounts]);
+     * const tx = new Transaction();
+     * //Apply the fee rate part at the beginning of the transaction (specifically setComputeUnitLimit & setComputeUnitPrice)
+     * SolanaFees.applyFeeRateBegin(tx, feeRate);
+     * //Add instructions here
+     * tx.add(instruction1);
+     * tx.add(instruction2);
+     * //Set the fee payer
+     * tx.feePayer = feePayerPublicKey;
+     * //Apply the fee rate part at the end of the transaction (specifically the transfer to the bribe account, e.g. Jito tip)
+     * SolanaFees.applyFeeRateEnd(tx, feeRate);
+     * ```
      *
      * @param tx
      * @param computeBudget
      * @param feeRate
      */
-    applyFeeRateBegin(tx, computeBudget, feeRate) {
+    static applyFeeRateBegin(tx, computeBudget, feeRate) {
         if (feeRate == null)
             return;
         const hashArr = feeRate.split("#");
@@ -336,14 +369,29 @@ class SolanaFees {
         }
     }
     /**
-     * Applies fee rate to the end of the transaction (has to be called after feePayer is set for the tx),
-     *  specifically adds the bribe SystemProgram.transfer instruction
+     * Applies fee rate to a transaction, should be called after adding instructions to the transaction, specifically
+     *  it adds the adds the bribe SystemProgram.transfer instruction.
+     *
+     * @example
+     * ```typescript
+     * const feeRate = solanaFees.getFeeRate([...writeableAccounts]);
+     * const tx = new Transaction();
+     * //Apply the fee rate part at the beginning of the transaction (specifically setComputeUnitLimit & setComputeUnitPrice)
+     * SolanaFees.applyFeeRateBegin(tx, feeRate);
+     * //Add instructions here
+     * tx.add(instruction1);
+     * tx.add(instruction2);
+     * //Set the fee payer
+     * tx.feePayer = feePayerPublicKey;
+     * //Apply the fee rate part at the end of the transaction (specifically the transfer to the bribe account, e.g. Jito tip)
+     * SolanaFees.applyFeeRateEnd(tx, feeRate);
+     * ```
      *
      * @param tx
      * @param computeBudget
      * @param feeRate
      */
-    applyFeeRateEnd(tx, computeBudget, feeRate) {
+    static applyFeeRateEnd(tx, computeBudget, feeRate) {
         if (feeRate == null)
             return;
         const hashArr = feeRate.split("#");
@@ -370,8 +418,8 @@ class SolanaFees {
     /**
      * Checks if the transaction should be submitted over Jito and if yes submits it
      *
-     * @param tx
-     * @param options
+     * @param tx Raw signed transaction to be attempted to be sent over Jito
+     * @param options Send options for the sendTransaction RPC call
      * @returns {Promise<string | null>} null if the transaction was not sent over Jito, tx signature when tx was sent over Jito
      */
     submitTx(tx, options) {

--- a/dist/solana/chain/modules/SolanaFees.js
+++ b/dist/solana/chain/modules/SolanaFees.js
@@ -4,6 +4,11 @@ exports.SolanaFees = void 0;
 const web3_js_1 = require("@solana/web3.js");
 const Utils_1 = require("../../../utils/Utils");
 const MAX_FEE_AGE = 5000;
+/**
+ * Fee estimation service for Solana chains.
+ *
+ * @category Chain Interface
+ */
 class SolanaFees {
     constructor(connection, maxFeeMicroLamports = 250000, numSamples = 8, period = 150, useHeliusApi = "auto", heliusFeeLevel = "veryHigh", getStaticFee, bribeData) {
         this.heliusApiSupported = true;

--- a/dist/solana/chain/modules/SolanaSlots.js
+++ b/dist/solana/chain/modules/SolanaSlots.js
@@ -6,7 +6,7 @@ class SolanaSlots extends SolanaModule_1.SolanaModule {
     constructor() {
         super(...arguments);
         this.SLOT_CACHE_SLOTS = 12;
-        this.SLOT_CACHE_TIME = this.SLOT_CACHE_SLOTS * this.root.SLOT_TIME;
+        this.SLOT_CACHE_TIME = this.SLOT_CACHE_SLOTS * this.root._SLOT_TIME;
         this.slotCache = {};
     }
     /**
@@ -59,7 +59,7 @@ class SolanaSlots extends SolanaModule_1.SolanaModule {
     async getSlot(commitment) {
         let cachedSlotData = this.slotCache[commitment];
         if (cachedSlotData != null && Date.now() - cachedSlotData.timestamp < this.SLOT_CACHE_TIME) {
-            return (await cachedSlotData.slot) + Math.floor((Date.now() - cachedSlotData.timestamp) / this.root.SLOT_TIME);
+            return (await cachedSlotData.slot) + Math.floor((Date.now() - cachedSlotData.timestamp) / this.root._SLOT_TIME);
         }
         cachedSlotData = this.fetchAndSaveSlot(commitment);
         return await cachedSlotData.slot;

--- a/dist/solana/chain/modules/SolanaTransactions.d.ts
+++ b/dist/solana/chain/modules/SolanaTransactions.d.ts
@@ -4,10 +4,21 @@ import { Finality, SendOptions, Signer, Transaction } from "@solana/web3.js";
 import { SolanaModule } from "../SolanaModule";
 import { Buffer } from "buffer";
 import { SolanaSigner } from "../../wallet/SolanaSigner";
+/**
+ * Solana unsigned transaction type, optionally also contains additional signers which should be used to additionally
+ *  sign the transaction.
+ *
+ * @category Chain Interface
+ */
 export type SolanaTx = {
     tx: Transaction;
     signers: Signer[];
 };
+/**
+ * Alias for signed Solana transaction, uses the native transaction type of `@solana/web3.js`
+ *
+ * @category Chain Interface
+ */
 export type SignedSolanaTx = Transaction;
 export declare class SolanaTransactions extends SolanaModule {
     private cbkBeforeTxSigned?;

--- a/dist/solana/connection/ConnectionWithRetries.d.ts
+++ b/dist/solana/connection/ConnectionWithRetries.d.ts
@@ -1,0 +1,18 @@
+import { Commitment, Connection, ConnectionConfig } from "@solana/web3.js";
+export type ConnectionWithRetriesConfig = ConnectionConfig & {
+    retryPolicy?: {
+        maxRetries?: number;
+        delay?: number;
+        exponential?: boolean;
+    };
+    requestTimeout?: number;
+};
+export declare class ConnectionWithRetries extends Connection {
+    readonly retryPolicy?: {
+        maxRetries?: number;
+        delay?: number;
+        exponential?: boolean;
+    };
+    readonly requestTimeout: number;
+    constructor(endpoint: string, commitmentOrConfig?: Commitment | ConnectionWithRetriesConfig);
+}

--- a/dist/solana/connection/ConnectionWithRetries.d.ts
+++ b/dist/solana/connection/ConnectionWithRetries.d.ts
@@ -7,12 +7,29 @@ export type ConnectionWithRetriesConfig = ConnectionConfig & {
     };
     requestTimeout?: number;
 };
+/**
+ * Solana connection with retry logic and request timeout handling for RPC calls.
+ *
+ * @category Providers
+ */
 export declare class ConnectionWithRetries extends Connection {
+    /**
+     * Retry policy used for RPC requests.
+     */
     readonly retryPolicy?: {
         maxRetries?: number;
         delay?: number;
         exponential?: boolean;
     };
+    /**
+     * Per-request timeout in milliseconds.
+     */
     readonly requestTimeout: number;
+    /**
+     * Constructs a retry-enabled Solana connection.
+     *
+     * @param endpoint RPC endpoint URL
+     * @param commitmentOrConfig Commitment level or full connection configuration
+     */
     constructor(endpoint: string, commitmentOrConfig?: Commitment | ConnectionWithRetriesConfig);
 }

--- a/dist/solana/connection/ConnectionWithRetries.js
+++ b/dist/solana/connection/ConnectionWithRetries.js
@@ -1,0 +1,60 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ConnectionWithRetries = void 0;
+const web3_js_1 = require("@solana/web3.js");
+const Utils_1 = require("../../utils/Utils");
+class ConnectionWithRetries extends web3_js_1.Connection {
+    constructor(endpoint, commitmentOrConfig) {
+        let config;
+        if (typeof (commitmentOrConfig) === "string") {
+            config = { commitment: commitmentOrConfig };
+        }
+        else {
+            config = commitmentOrConfig ?? {};
+        }
+        config.fetch = (input, init) => (0, Utils_1.tryWithRetries)(async () => {
+            let timedOut = false;
+            const abortController = new AbortController();
+            const timeoutHandle = setTimeout(() => {
+                timedOut = true;
+                abortController.abort('Timed out');
+            }, this.requestTimeout);
+            let originalSignal;
+            if (init?.signal != null) {
+                originalSignal = init.signal;
+                init.signal.addEventListener('abort', (reason) => {
+                    clearTimeout(timeoutHandle);
+                    abortController.abort(reason);
+                });
+            }
+            const result = await fetch(input, {
+                ...init,
+                signal: abortController.signal
+            }).catch((e) => {
+                console.error('SolanaWalletProvider: fetchWithTimeout(' + typeof e + '): ', e);
+                if (e.name === 'AbortError' &&
+                    (originalSignal == null || !originalSignal.aborted) &&
+                    timedOut) {
+                    throw new Error('Network request timed out');
+                }
+                else {
+                    throw e;
+                }
+            });
+            if (Math.floor(result.status / 100) === 5) {
+                throw new Error(`Internal server error: ${result.status}`);
+            }
+            if (result.status === 429) {
+                throw new Error(`Too many requests (429)`);
+            }
+            return result;
+        }, this.retryPolicy, (e) => !e?.message?.startsWith?.("Internal server error: ") &&
+            e?.message !== "Network request timed out" &&
+            e?.message !== "Too many requests (429)", init?.signal ?? undefined);
+        config.disableRetryOnRateLimit = true;
+        super(endpoint, commitmentOrConfig);
+        this.retryPolicy = config?.retryPolicy;
+        this.requestTimeout = config?.requestTimeout ?? 15 * 1000;
+    }
+}
+exports.ConnectionWithRetries = ConnectionWithRetries;

--- a/dist/solana/connection/ConnectionWithRetries.js
+++ b/dist/solana/connection/ConnectionWithRetries.js
@@ -3,7 +3,18 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.ConnectionWithRetries = void 0;
 const web3_js_1 = require("@solana/web3.js");
 const Utils_1 = require("../../utils/Utils");
+/**
+ * Solana connection with retry logic and request timeout handling for RPC calls.
+ *
+ * @category Providers
+ */
 class ConnectionWithRetries extends web3_js_1.Connection {
+    /**
+     * Constructs a retry-enabled Solana connection.
+     *
+     * @param endpoint RPC endpoint URL
+     * @param commitmentOrConfig Commitment level or full connection configuration
+     */
     constructor(endpoint, commitmentOrConfig) {
         let config;
         if (typeof (commitmentOrConfig) === "string") {

--- a/dist/solana/events/SolanaChainEvents.d.ts
+++ b/dist/solana/events/SolanaChainEvents.d.ts
@@ -29,7 +29,13 @@ export declare class SolanaChainEvents extends SolanaChainEventsBrowser {
      * @private
      */
     private checkEvents;
-    setupHttpPolling(): Promise<void>;
+    private setupHttpPolling;
+    /**
+     * @inheritDoc
+     */
     init(noAutomaticPoll?: boolean): Promise<void>;
+    /**
+     * @inheritDoc
+     */
     stop(): Promise<void>;
 }

--- a/dist/solana/events/SolanaChainEvents.js
+++ b/dist/solana/events/SolanaChainEvents.js
@@ -72,6 +72,9 @@ class SolanaChainEvents extends SolanaChainEventsBrowser_1.SolanaChainEventsBrow
         };
         await func();
     }
+    /**
+     * @inheritDoc
+     */
     async init(noAutomaticPoll) {
         if (noAutomaticPoll)
             return;
@@ -82,6 +85,9 @@ class SolanaChainEvents extends SolanaChainEventsBrowser_1.SolanaChainEventsBrow
         await this.setupHttpPolling();
         this.setupWebsocket();
     }
+    /**
+     * @inheritDoc
+     */
     stop() {
         this.stopped = true;
         if (this.timeout != null)

--- a/dist/solana/events/SolanaChainEventsBrowser.d.ts
+++ b/dist/solana/events/SolanaChainEventsBrowser.d.ts
@@ -5,12 +5,22 @@ import { SolanaSwapProgram } from "../swaps/SolanaSwapProgram";
 import { Connection } from "@solana/web3.js";
 import { InstructionWithAccounts, ProgramEvent } from "../program/modules/SolanaProgramEvents";
 import { SwapProgram } from "../swaps/programTypes";
+/**
+ * Parsed event payload grouped by originating transaction metadata.
+ *
+ * @category Events
+ */
 export type EventObject = {
     events: ProgramEvent<SwapProgram>[];
     instructions?: (InstructionWithAccounts<SwapProgram> | null)[];
     blockTime: number;
     signature: string;
 };
+/**
+ * Current state of Solana event listener progress.
+ *
+ * @category Events
+ */
 export type SolanaEventListenerState = {
     signature: string;
     slot: number;
@@ -19,6 +29,8 @@ export type SolanaEventListenerState = {
  * Solana on-chain event handler for front-end systems without access to fs, uses pure WS to subscribe, might lose
  *  out on some events if the network is unreliable, front-end systems should take this into consideration and not
  *  rely purely on events
+ *
+ * @category Events
  */
 export declare class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, SolanaEventListenerState> {
     protected readonly listeners: EventListener<SolanaSwapData>[];

--- a/dist/solana/events/SolanaChainEventsBrowser.d.ts
+++ b/dist/solana/events/SolanaChainEventsBrowser.d.ts
@@ -17,12 +17,18 @@ export type EventObject = {
     signature: string;
 };
 /**
- * Current state of Solana event listener progress.
+ * Current cursor of Solana event listener state.
  *
  * @category Events
  */
 export type SolanaEventListenerState = {
+    /**
+     * Last processed transaction's signature
+     */
     signature: string;
+    /**
+     * Last processed transaction's slot
+     */
     slot: number;
 };
 /**
@@ -33,15 +39,32 @@ export type SolanaEventListenerState = {
  * @category Events
  */
 export declare class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, SolanaEventListenerState> {
+    /**
+     * @internal
+     */
     protected readonly listeners: EventListener<SolanaSwapData>[];
+    /**
+     * @internal
+     */
     protected readonly connection: Connection;
+    /**
+     * @internal
+     */
     protected readonly solanaSwapProgram: SolanaSwapProgram;
+    /**
+     * @internal
+     */
     protected eventListeners: number[];
+    /**
+     * @internal
+     */
     protected readonly logger: {
         debug: (msg: string, ...args: any[]) => false | void;
         info: (msg: string, ...args: any[]) => false | void;
         warn: (msg: string, ...args: any[]) => false | void;
-        error: (msg: string, ...args: any[]) => false | void;
+        error: (msg: string, ...args: any[]) => false | void; /**
+         * @internal
+         */
     };
     private readonly logFetchLimit;
     private signaturesProcessing;
@@ -82,28 +105,37 @@ export declare class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapD
      * @returns {() => Promise<SolanaSwapData>} getter to be passed to InitializeEvent constructor
      */
     private getSwapDataGetter;
+    /**
+     * @internal
+     */
     protected parseInitializeEvent(data: IdlEvents<SwapProgram>["InitializeEvent"], eventObject: EventObject): InitializeEvent<SolanaSwapData>;
+    /**
+     * @internal
+     */
     protected parseRefundEvent(data: IdlEvents<SwapProgram>["RefundEvent"]): RefundEvent<SolanaSwapData>;
+    /**
+     * @internal
+     */
     protected parseClaimEvent(data: IdlEvents<SwapProgram>["ClaimEvent"]): ClaimEvent<SolanaSwapData>;
     /**
      * Processes event as received from the chain, parses it & calls event listeners
      *
      * @param eventObject
-     * @protected
+     * @internal
      */
     protected processEvent(eventObject: EventObject): Promise<void>;
     /**
      * Returns websocket event handler for specific event type
      *
      * @param name
-     * @protected
+     * @internal
      * @returns event handler to be passed to program's addEventListener function
      */
     protected getWsEventHandler<E extends "InitializeEvent" | "RefundEvent" | "ClaimEvent">(name: E): (data: IdlEvents<SwapProgram>[E], slotNumber: number, signature: string) => void;
     /**
      * Sets up event handlers listening for swap events over websocket
      *
-     * @protected
+     * @internal
      */
     protected setupWebsocket(): void;
     /**

--- a/dist/solana/events/SolanaChainEventsBrowser.js
+++ b/dist/solana/events/SolanaChainEventsBrowser.js
@@ -17,8 +17,17 @@ const PROCESSED_SIGNATURES_BACKLOG = 100;
  */
 class SolanaChainEventsBrowser {
     constructor(connection, solanaSwapContract, logFetchLimit) {
+        /**
+         * @internal
+         */
         this.listeners = [];
+        /**
+         * @internal
+         */
         this.eventListeners = [];
+        /**
+         * @internal
+         */
         this.logger = (0, Utils_1.getLogger)("SolanaChainEventsBrowser: ");
         this.signaturesProcessing = {};
         this.processedSignatures = [];
@@ -49,8 +58,8 @@ class SolanaChainEventsBrowser {
             throw new Error(`Transaction 'meta' not found for Solana tx: ${signature}`);
         if (transaction.meta.err != null || transaction.meta.logMessages == null)
             return null;
-        const instructions = this.solanaSwapProgram.Events.decodeInstructions(transaction.transaction.message);
-        const events = this.solanaSwapProgram.Events.parseLogs(transaction.meta.logMessages);
+        const instructions = this.solanaSwapProgram._Events.decodeInstructions(transaction.transaction.message);
+        const events = this.solanaSwapProgram._Events.parseLogs(transaction.meta.logMessages);
         return {
             instructions,
             events,
@@ -104,7 +113,7 @@ class SolanaChainEventsBrowser {
             throw new Error("Transaction 'meta' not found!");
         if (transaction.meta.err != null)
             return null;
-        return this.solanaSwapProgram.Events.decodeInstructions(transaction.transaction.message);
+        return this.solanaSwapProgram._Events.decodeInstructions(transaction.transaction.message);
     }
     /**
      * Returns async getter for fetching on-demand initialize event swap data
@@ -128,6 +137,9 @@ class SolanaChainEventsBrowser {
             return SolanaSwapData_1.SolanaSwapData.fromInstruction(initIx, txoHash);
         };
     }
+    /**
+     * @internal
+     */
     parseInitializeEvent(data, eventObject) {
         const paymentHash = buffer_1.Buffer.from(data.hash).toString("hex");
         const txoHash = buffer_1.Buffer.from(data.txoHash).toString("hex");
@@ -136,6 +148,9 @@ class SolanaChainEventsBrowser {
             " txoHash: " + txoHash + " escrowHash: " + escrowHash);
         return new base_1.InitializeEvent(escrowHash, SwapTypeEnum_1.SwapTypeEnum.toChainSwapType(data.kind), (0, Utils_1.onceAsync)(this.getSwapDataGetter(eventObject, txoHash)));
     }
+    /**
+     * @internal
+     */
     parseRefundEvent(data) {
         const paymentHash = buffer_1.Buffer.from(data.hash).toString("hex");
         const escrowHash = (0, Utils_1.toEscrowHash)(paymentHash, data.sequence);
@@ -143,6 +158,9 @@ class SolanaChainEventsBrowser {
             " escrowHash: " + escrowHash);
         return new base_1.RefundEvent(escrowHash);
     }
+    /**
+     * @internal
+     */
     parseClaimEvent(data) {
         const secret = buffer_1.Buffer.from(data.secret).toString("hex");
         const paymentHash = buffer_1.Buffer.from(data.hash).toString("hex");
@@ -155,7 +173,7 @@ class SolanaChainEventsBrowser {
      * Processes event as received from the chain, parses it & calls event listeners
      *
      * @param eventObject
-     * @protected
+     * @internal
      */
     async processEvent(eventObject) {
         let parsedEvents = eventObject.events.map(event => {
@@ -171,6 +189,8 @@ class SolanaChainEventsBrowser {
                     parsedEvent = this.parseInitializeEvent(event.data, eventObject);
                     break;
             }
+            if (parsedEvent == null)
+                return null;
             parsedEvent.meta = {
                 blockTime: eventObject.blockTime,
                 timestamp: eventObject.blockTime,
@@ -186,7 +206,7 @@ class SolanaChainEventsBrowser {
      * Returns websocket event handler for specific event type
      *
      * @param name
-     * @protected
+     * @internal
      * @returns event handler to be passed to program's addEventListener function
      */
     getWsEventHandler(name) {
@@ -209,7 +229,7 @@ class SolanaChainEventsBrowser {
     /**
      * Sets up event handlers listening for swap events over websocket
      *
-     * @protected
+     * @internal
      */
     setupWebsocket() {
         const program = this.solanaSwapProgram.program;

--- a/dist/solana/events/SolanaChainEventsBrowser.js
+++ b/dist/solana/events/SolanaChainEventsBrowser.js
@@ -12,6 +12,8 @@ const PROCESSED_SIGNATURES_BACKLOG = 100;
  * Solana on-chain event handler for front-end systems without access to fs, uses pure WS to subscribe, might lose
  *  out on some events if the network is unreliable, front-end systems should take this into consideration and not
  *  rely purely on events
+ *
+ * @category Events
  */
 class SolanaChainEventsBrowser {
     constructor(connection, solanaSwapContract, logFetchLimit) {

--- a/dist/solana/program/SolanaProgramBase.d.ts
+++ b/dist/solana/program/SolanaProgramBase.d.ts
@@ -9,37 +9,48 @@ import { Buffer } from "buffer";
  * Base class providing program specific utilities
  */
 export declare class SolanaProgramBase<T extends Idl> {
+    /**
+     * @internal
+     */
     protected readonly logger: {
-        debug: (msg: string, ...args: any[]) => false | void; /**
-         * Derives static PDA address from the seed
-         *
-         * @param seed
-         */
+        debug: (msg: string, ...args: any[]) => false | void;
         info: (msg: string, ...args: any[]) => false | void;
         warn: (msg: string, ...args: any[]) => false | void;
         error: (msg: string, ...args: any[]) => false | void;
     };
     program: Program<T>;
-    readonly Events: SolanaProgramEvents<T>;
-    readonly Chain: SolanaChainInterface;
+    /**
+     * @internal
+     */
+    readonly _Events: SolanaProgramEvents<T>;
+    /**
+     * @internal
+     */
+    readonly _Chain: SolanaChainInterface;
     constructor(chainInterface: SolanaChainInterface, programIdl: any, programAddress?: string);
     /**
      * Derives static PDA address from the seed
      *
      * @param seed
+     *
+     * @internal
      */
-    pda(seed: string): PublicKey;
+    protected pda(seed: string): PublicKey;
     /**
      * Returns a function for deriving a dynamic PDA address from seed + dynamic arguments
      *
      * @param seed
      * @param func function translating the function argument to Buffer[]
+     *
+     * @internal
      */
-    pda<T extends Array<any>>(seed: string, func: (...args: T) => Buffer[]): (...args: T) => PublicKey;
+    protected pda<T extends Array<any>>(seed: string, func: (...args: T) => Buffer[]): (...args: T) => PublicKey;
     /**
      * Returns a function for deriving a dynamic deterministic keypair from dynamic arguments
      *
      * @param func function translating the function argument to Buffer[] to be used for deriving the keypair
+     *
+     * @internal
      */
-    keypair<T extends Array<any>>(func: (...args: T) => Buffer[]): (...args: T) => Keypair;
+    _keypair<T extends Array<any>>(func: (...args: T) => Buffer[]): (...args: T) => Keypair;
 }

--- a/dist/solana/program/SolanaProgramBase.js
+++ b/dist/solana/program/SolanaProgramBase.js
@@ -18,7 +18,7 @@ class SolanaProgramBase {
          */
         this.logger = (0, Utils_1.getLogger)(this.constructor.name + ": ");
         this._Chain = chainInterface;
-        this.program = new anchor_1.Program(programIdl, programAddress || programIdl.metadata.address, new anchor_1.AnchorProvider(chainInterface.connection, new SolanaKeypairWallet_1.SolanaKeypairWallet(web3_js_1.Keypair.generate()), {}));
+        this.program = new anchor_1.Program(programIdl, programAddress || programIdl.metadata.address, new anchor_1.AnchorProvider(chainInterface._connection, new SolanaKeypairWallet_1.SolanaKeypairWallet(web3_js_1.Keypair.generate()), {}));
         this._Events = new SolanaProgramEvents_1.SolanaProgramEvents(chainInterface, this);
     }
     pda(seed, func) {

--- a/dist/solana/program/SolanaProgramBase.js
+++ b/dist/solana/program/SolanaProgramBase.js
@@ -13,10 +13,13 @@ const Utils_1 = require("../../utils/Utils");
  */
 class SolanaProgramBase {
     constructor(chainInterface, programIdl, programAddress) {
+        /**
+         * @internal
+         */
         this.logger = (0, Utils_1.getLogger)(this.constructor.name + ": ");
-        this.Chain = chainInterface;
+        this._Chain = chainInterface;
         this.program = new anchor_1.Program(programIdl, programAddress || programIdl.metadata.address, new anchor_1.AnchorProvider(chainInterface.connection, new SolanaKeypairWallet_1.SolanaKeypairWallet(web3_js_1.Keypair.generate()), {}));
-        this.Events = new SolanaProgramEvents_1.SolanaProgramEvents(chainInterface, this);
+        this._Events = new SolanaProgramEvents_1.SolanaProgramEvents(chainInterface, this);
     }
     pda(seed, func) {
         if (func == null) {
@@ -31,8 +34,10 @@ class SolanaProgramBase {
      * Returns a function for deriving a dynamic deterministic keypair from dynamic arguments
      *
      * @param func function translating the function argument to Buffer[] to be used for deriving the keypair
+     *
+     * @internal
      */
-    keypair(func) {
+    _keypair(func) {
         return (...args) => {
             const res = func(...args);
             const buff = (0, sha2_1.sha256)(buffer_1.Buffer.concat(res));

--- a/dist/solana/swaps/SolanaSwapData.d.ts
+++ b/dist/solana/swaps/SolanaSwapData.d.ts
@@ -29,27 +29,90 @@ export declare function isSerializedData(obj: any): obj is ({
     type: "sol";
 } & Serialized<SolanaSwapData>);
 /**
+ * Represents Solana swap data for executing PrTLC (on-chain) or HTLC (lightning) based swaps.
+ *
  * @category Swaps
  */
 export declare class SolanaSwapData extends SwapData {
+    /**
+     * Offerer address funding the swap.
+     */
     offerer: PublicKey;
+    /**
+     * Claimer address receiving the swap funds.
+     */
     claimer: PublicKey;
+    /**
+     * Token mint used for the swap.
+     */
     token: PublicKey;
+    /**
+     * Swap amount.
+     */
     amount: BN;
+    /**
+     * Payment hash identifying the swap.
+     */
     paymentHash: string;
+    /**
+     * Swap sequence used for uniqueness.
+     */
     sequence: BN;
+    /**
+     * Swap expiry timestamp.
+     */
     expiry: BN;
+    /**
+     * Nonce used in claim hash derivation.
+     */
     nonce: BN;
+    /**
+     * Required bitcoin confirmations for claim.
+     */
     confirmations: number;
+    /**
+     * Whether funds are paid out to claimer wallet directly.
+     */
     payOut: boolean;
+    /**
+     * Solana on-chain swap kind discriminator.
+     */
     kind: number;
+    /**
+     * Whether funds are paid in from offerer wallet.
+     */
     payIn: boolean;
+    /**
+     * Optional claimer associated token account.
+     */
     claimerAta?: PublicKey;
+    /**
+     * Optional offerer associated token account.
+     */
     offererAta?: PublicKey;
+    /**
+     * Security deposit amount.
+     */
     securityDeposit: BN;
+    /**
+     * Claimer bounty amount.
+     */
     claimerBounty: BN;
+    /**
+     * Optional txo hash hint.
+     */
     txoHash?: string;
+    /**
+     * Creates swap data from structured constructor arguments.
+     *
+     * @param args Swap data fields
+     */
     constructor(args: SolanaSwapDataCtorArgs);
+    /**
+     * Deserializes swap data from serialized storage representation.
+     *
+     * @param data Serialized swap data from {@link SolanaSwapData.serialize}
+     */
     constructor(data: {
         type: "sol";
     } & Serialized<SolanaSwapData>);
@@ -155,23 +218,45 @@ export declare class SolanaSwapData extends SwapData {
      * @inheritDoc
      */
     getTotalDeposit(): bigint;
+    /**
+     * Serializes the swap data into the Solana program `SwapData` struct representation.
+     */
     toSwapDataStruct(): IdlTypes<SwapProgram>["SwapData"];
+    /**
+     * Checks whether the provided escrow account matches this swap data.
+     *
+     * @param account Escrow account data fetched from chain
+     */
     correctPDA(account: IdlAccounts<SwapProgram>["escrowState"]): boolean;
     /**
      * @inheritDoc
      */
     equals(other: SolanaSwapData): boolean;
     /**
-     * Converts initialize instruction data into {SolanaSwapData}
+     * Converts initialize instruction data into {@link SolanaSwapData}.
      *
-     * @param initIx
-     * @param txoHash
-     * @private
-     * @returns {SolanaSwapData} converted and parsed swap data
+     * @param initIx Decoded initialize instruction
+     * @param txoHash Parsed txo hash hint from initialize event
+     * @returns Converted and parsed swap data
      */
     static fromInstruction(initIx: InitInstruction, txoHash: string): SolanaSwapData;
+    /**
+     * Deserializes swap data from an on-chain escrow account state.
+     *
+     * @param account Escrow account state as returned by Anchor
+     */
     static fromEscrowState(account: IdlAccounts<SwapProgram>["escrowState"]): SolanaSwapData;
+    /**
+     * Converts abstract swap type to Solana program kind discriminator.
+     *
+     * @param type Chain-agnostic swap type
+     */
     static typeToKind(type: ChainSwapType): number;
+    /**
+     * Converts Solana program kind discriminator to abstract swap type.
+     *
+     * @param value Solana program swap kind value
+     */
     static kindToType(value: number): ChainSwapType;
     /**
      * @inheritDoc

--- a/dist/solana/swaps/SolanaSwapData.js
+++ b/dist/solana/swaps/SolanaSwapData.js
@@ -15,6 +15,8 @@ function isSerializedData(obj) {
 }
 exports.isSerializedData = isSerializedData;
 /**
+ * Represents Solana swap data for executing PrTLC (on-chain) or HTLC (lightning) based swaps.
+ *
  * @category Swaps
  */
 class SolanaSwapData extends base_1.SwapData {
@@ -239,6 +241,9 @@ class SolanaSwapData extends base_1.SwapData {
     getTotalDeposit() {
         return (0, Utils_1.toBigInt)(this.claimerBounty.lt(this.securityDeposit) ? this.securityDeposit : this.claimerBounty);
     }
+    /**
+     * Serializes the swap data into the Solana program `SwapData` struct representation.
+     */
     toSwapDataStruct() {
         return {
             kind: SwapTypeEnum_1.SwapTypeEnum.fromNumber(this.kind),
@@ -252,6 +257,11 @@ class SolanaSwapData extends base_1.SwapData {
             sequence: this.sequence
         };
     }
+    /**
+     * Checks whether the provided escrow account matches this swap data.
+     *
+     * @param account Escrow account data fetched from chain
+     */
     correctPDA(account) {
         return SwapTypeEnum_1.SwapTypeEnum.toNumber(account.data.kind) === this.kind &&
             account.data.confirmations === this.confirmations &&
@@ -306,12 +316,11 @@ class SolanaSwapData extends base_1.SwapData {
             other.token.equals(this.token);
     }
     /**
-     * Converts initialize instruction data into {SolanaSwapData}
+     * Converts initialize instruction data into {@link SolanaSwapData}.
      *
-     * @param initIx
-     * @param txoHash
-     * @private
-     * @returns {SolanaSwapData} converted and parsed swap data
+     * @param initIx Decoded initialize instruction
+     * @param txoHash Parsed txo hash hint from initialize event
+     * @returns Converted and parsed swap data
      */
     static fromInstruction(initIx, txoHash) {
         const paymentHash = buffer_1.Buffer.from(initIx.data.swapData.hash);
@@ -343,6 +352,11 @@ class SolanaSwapData extends base_1.SwapData {
             txoHash
         });
     }
+    /**
+     * Deserializes swap data from an on-chain escrow account state.
+     *
+     * @param account Escrow account state as returned by Anchor
+     */
     static fromEscrowState(account) {
         const data = account.data;
         return new SolanaSwapData({
@@ -364,6 +378,11 @@ class SolanaSwapData extends base_1.SwapData {
             claimerBounty: account.claimerBounty
         });
     }
+    /**
+     * Converts abstract swap type to Solana program kind discriminator.
+     *
+     * @param type Chain-agnostic swap type
+     */
     static typeToKind(type) {
         switch (type) {
             case base_1.ChainSwapType.HTLC:
@@ -376,6 +395,11 @@ class SolanaSwapData extends base_1.SwapData {
                 return 3;
         }
     }
+    /**
+     * Converts Solana program kind discriminator to abstract swap type.
+     *
+     * @param value Solana program swap kind value
+     */
     static kindToType(value) {
         switch (value) {
             case 0:

--- a/dist/solana/swaps/SolanaSwapProgram.d.ts
+++ b/dist/solana/swaps/SolanaSwapProgram.d.ts
@@ -9,11 +9,8 @@ import { SwapProgram } from "./programTypes";
 import { SolanaChainInterface } from "../chain/SolanaChainInterface";
 import { SolanaProgramBase } from "../program/SolanaProgramBase";
 import { SolanaTx } from "../chain/modules/SolanaTransactions";
-import { SwapInit, SolanaPreFetchData, SolanaPreFetchVerification } from "./modules/SwapInit";
+import { SolanaPreFetchData, SolanaPreFetchVerification } from "./modules/SwapInit";
 import { SolanaDataAccount, StoredDataAccount } from "./modules/SolanaDataAccount";
-import { SwapRefund } from "./modules/SwapRefund";
-import { SwapClaim } from "./modules/SwapClaim";
-import { SolanaLpVault } from "./modules/SolanaLpVault";
 import { Buffer } from "buffer";
 import { SolanaSigner } from "../wallet/SolanaSigner";
 /**
@@ -28,20 +25,24 @@ export declare class SolanaSwapProgram extends SolanaProgramBase<SwapProgram> im
     readonly ESCROW_STATE_RENT_EXEMPT = 2658720;
     /**
      * PDA of the swap vault authority.
+     * @internal
      */
-    readonly SwapVaultAuthority: PublicKey;
+    readonly _SwapVaultAuthority: PublicKey;
     /**
      * PDA helper for global token vault accounts.
+     * @internal
      */
-    readonly SwapVault: (tokenAddress: PublicKey) => PublicKey;
+    readonly _SwapVault: (tokenAddress: PublicKey) => PublicKey;
     /**
      * PDA helper for per-user token vault accounts.
+     * @internal
      */
-    readonly SwapUserVault: (publicKey: PublicKey, tokenAddress: PublicKey) => PublicKey;
+    readonly _SwapUserVault: (publicKey: PublicKey, tokenAddress: PublicKey) => PublicKey;
     /**
      * PDA helper for escrow state accounts.
+     * @internal
      */
-    readonly SwapEscrowState: (hash: Buffer) => PublicKey;
+    readonly _SwapEscrowState: (hash: Buffer) => PublicKey;
     /**
      * @inheritDoc
      */
@@ -68,28 +69,30 @@ export declare class SolanaSwapProgram extends SolanaProgramBase<SwapProgram> im
     private readonly refundGracePeriod;
     /**
      * Authorization grace period in seconds.
+     * @internal
      */
-    readonly authGracePeriod: number;
+    readonly _authGracePeriod: number;
     /**
      * Swap initialization service.
      */
-    readonly Init: SwapInit;
+    private readonly Init;
     /**
      * Swap refund service.
      */
-    readonly Refund: SwapRefund;
+    private readonly Refund;
     /**
      * Swap claim service.
      */
-    readonly Claim: SwapClaim;
-    /**
-     * Temporary data-account lifecycle service.
-     */
-    readonly DataAccount: SolanaDataAccount;
+    private readonly Claim;
     /**
      * LP vault interaction service.
      */
-    readonly LpVault: SolanaLpVault;
+    private readonly LpVault;
+    /**
+     * Temporary data-account lifecycle service.
+     * @internal
+     */
+    readonly _DataAccount: SolanaDataAccount;
     constructor(chainInterface: SolanaChainInterface, btcRelay: SolanaBtcRelay<any>, storage: IStorageManager<StoredDataAccount>, programAddress?: string);
     /**
      * @inheritDoc

--- a/dist/solana/swaps/SolanaSwapProgram.d.ts
+++ b/dist/solana/swaps/SolanaSwapProgram.d.ts
@@ -17,25 +17,78 @@ import { SolanaLpVault } from "./modules/SolanaLpVault";
 import { Buffer } from "buffer";
 import { SolanaSigner } from "../wallet/SolanaSigner";
 /**
+ * Solana swap (escrow manager) program representation handling PrTLC (on-chain) and HTLC (lightning) based swaps.
+ *
  * @category Swaps
  */
 export declare class SolanaSwapProgram extends SolanaProgramBase<SwapProgram> implements SwapContract<SolanaSwapData, SolanaTx, SolanaPreFetchData, SolanaPreFetchVerification, SolanaSigner, "SOLANA"> {
+    /**
+     * Rent-exempt amount (lamports) for escrow state accounts.
+     */
     readonly ESCROW_STATE_RENT_EXEMPT = 2658720;
+    /**
+     * PDA of the swap vault authority.
+     */
     readonly SwapVaultAuthority: PublicKey;
+    /**
+     * PDA helper for global token vault accounts.
+     */
     readonly SwapVault: (tokenAddress: PublicKey) => PublicKey;
+    /**
+     * PDA helper for per-user token vault accounts.
+     */
     readonly SwapUserVault: (publicKey: PublicKey, tokenAddress: PublicKey) => PublicKey;
+    /**
+     * PDA helper for escrow state accounts.
+     */
     readonly SwapEscrowState: (hash: Buffer) => PublicKey;
+    /**
+     * @inheritDoc
+     */
     readonly chainId: "SOLANA";
+    /**
+     * @inheritDoc
+     */
     readonly claimWithSecretTimeout: number;
+    /**
+     * @inheritDoc
+     */
     readonly claimWithTxDataTimeout: number;
+    /**
+     * @inheritDoc
+     */
     readonly refundTimeout: number;
+    /**
+     * Grace period (seconds) applied to claimer-side expiry checks.
+     */
     readonly claimGracePeriod: number;
+    /**
+     * Grace period (seconds) applied to offerer-side expiry checks.
+     */
     readonly refundGracePeriod: number;
+    /**
+     * Authorization grace period in seconds.
+     */
     readonly authGracePeriod: number;
+    /**
+     * Swap initialization service.
+     */
     readonly Init: SwapInit;
+    /**
+     * Swap refund service.
+     */
     readonly Refund: SwapRefund;
+    /**
+     * Swap claim service.
+     */
     readonly Claim: SwapClaim;
+    /**
+     * Temporary data-account lifecycle service.
+     */
     readonly DataAccount: SolanaDataAccount;
+    /**
+     * LP vault interaction service.
+     */
     readonly LpVault: SolanaLpVault;
     constructor(chainInterface: SolanaChainInterface, btcRelay: SolanaBtcRelay<any>, storage: IStorageManager<StoredDataAccount>, programAddress?: string);
     /**
@@ -184,6 +237,12 @@ export declare class SolanaSwapProgram extends SolanaProgramBase<SwapProgram> im
      * @inheritDoc
      */
     getIntermediaryReputation(address: string, token: string): Promise<IntermediaryReputationType | null>;
+    /**
+     * Returns intermediary vault balance for a specific token.
+     *
+     * @param address Intermediary address
+     * @param token Token mint
+     */
     getIntermediaryBalance(address: PublicKey, token: PublicKey): Promise<bigint>;
     /**
      * @inheritDoc

--- a/dist/solana/swaps/SolanaSwapProgram.d.ts
+++ b/dist/solana/swaps/SolanaSwapProgram.d.ts
@@ -61,11 +61,11 @@ export declare class SolanaSwapProgram extends SolanaProgramBase<SwapProgram> im
     /**
      * Grace period (seconds) applied to claimer-side expiry checks.
      */
-    readonly claimGracePeriod: number;
+    private readonly claimGracePeriod;
     /**
      * Grace period (seconds) applied to offerer-side expiry checks.
      */
-    readonly refundGracePeriod: number;
+    private readonly refundGracePeriod;
     /**
      * Authorization grace period in seconds.
      */

--- a/dist/solana/swaps/SolanaSwapProgram.js
+++ b/dist/solana/swaps/SolanaSwapProgram.js
@@ -22,6 +22,8 @@ function toPublicKeyOrNull(str) {
 }
 const MAX_PARALLEL_COMMIT_STATUS_CHECKS = 5;
 /**
+ * Solana swap (escrow manager) program representation handling PrTLC (on-chain) and HTLC (lightning) based swaps.
+ *
  * @category Swaps
  */
 class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
@@ -29,21 +31,57 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
         super(chainInterface, programIdl, programAddress);
         ////////////////////////
         //// Constants
+        /**
+         * Rent-exempt amount (lamports) for escrow state accounts.
+         */
         this.ESCROW_STATE_RENT_EXEMPT = 2658720;
         ////////////////////////
         //// PDA accessors
+        /**
+         * PDA of the swap vault authority.
+         */
         this.SwapVaultAuthority = this.pda("authority");
+        /**
+         * PDA helper for global token vault accounts.
+         */
         this.SwapVault = this.pda("vault", (tokenAddress) => [tokenAddress.toBuffer()]);
+        /**
+         * PDA helper for per-user token vault accounts.
+         */
         this.SwapUserVault = this.pda("uservault", (publicKey, tokenAddress) => [publicKey.toBuffer(), tokenAddress.toBuffer()]);
+        /**
+         * PDA helper for escrow state accounts.
+         */
         this.SwapEscrowState = this.pda("state", (hash) => [hash]);
         ////////////////////////
         //// Timeouts
+        /**
+         * @inheritDoc
+         */
         this.chainId = "SOLANA";
+        /**
+         * @inheritDoc
+         */
         this.claimWithSecretTimeout = 45;
+        /**
+         * @inheritDoc
+         */
         this.claimWithTxDataTimeout = 120;
+        /**
+         * @inheritDoc
+         */
         this.refundTimeout = 45;
+        /**
+         * Grace period (seconds) applied to claimer-side expiry checks.
+         */
         this.claimGracePeriod = 10 * 60;
+        /**
+         * Grace period (seconds) applied to offerer-side expiry checks.
+         */
         this.refundGracePeriod = 10 * 60;
+        /**
+         * Authorization grace period in seconds.
+         */
         this.authGracePeriod = 5 * 60;
         this.Init = new SwapInit_1.SwapInit(chainInterface, this);
         this.Refund = new SwapRefund_1.SwapRefund(chainInterface, this);
@@ -469,6 +507,12 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
     getIntermediaryReputation(address, token) {
         return this.LpVault.getIntermediaryReputation(new web3_js_1.PublicKey(address), new web3_js_1.PublicKey(token));
     }
+    /**
+     * Returns intermediary vault balance for a specific token.
+     *
+     * @param address Intermediary address
+     * @param token Token mint
+     */
     getIntermediaryBalance(address, token) {
         return this.LpVault.getIntermediaryBalance(address, token);
     }

--- a/dist/solana/swaps/SolanaSwapProgram.js
+++ b/dist/solana/swaps/SolanaSwapProgram.js
@@ -39,20 +39,24 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
         //// PDA accessors
         /**
          * PDA of the swap vault authority.
+         * @internal
          */
-        this.SwapVaultAuthority = this.pda("authority");
+        this._SwapVaultAuthority = this.pda("authority");
         /**
          * PDA helper for global token vault accounts.
+         * @internal
          */
-        this.SwapVault = this.pda("vault", (tokenAddress) => [tokenAddress.toBuffer()]);
+        this._SwapVault = this.pda("vault", (tokenAddress) => [tokenAddress.toBuffer()]);
         /**
          * PDA helper for per-user token vault accounts.
+         * @internal
          */
-        this.SwapUserVault = this.pda("uservault", (publicKey, tokenAddress) => [publicKey.toBuffer(), tokenAddress.toBuffer()]);
+        this._SwapUserVault = this.pda("uservault", (publicKey, tokenAddress) => [publicKey.toBuffer(), tokenAddress.toBuffer()]);
         /**
          * PDA helper for escrow state accounts.
+         * @internal
          */
-        this.SwapEscrowState = this.pda("state", (hash) => [hash]);
+        this._SwapEscrowState = this.pda("state", (hash) => [hash]);
         ////////////////////////
         //// Timeouts
         /**
@@ -81,31 +85,32 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
         this.refundGracePeriod = 10 * 60;
         /**
          * Authorization grace period in seconds.
+         * @internal
          */
-        this.authGracePeriod = 5 * 60;
+        this._authGracePeriod = 5 * 60;
         this.Init = new SwapInit_1.SwapInit(chainInterface, this);
         this.Refund = new SwapRefund_1.SwapRefund(chainInterface, this);
         this.Claim = new SwapClaim_1.SwapClaim(chainInterface, this, btcRelay);
-        this.DataAccount = new SolanaDataAccount_1.SolanaDataAccount(chainInterface, this, storage);
+        this._DataAccount = new SolanaDataAccount_1.SolanaDataAccount(chainInterface, this, storage);
         this.LpVault = new SolanaLpVault_1.SolanaLpVault(chainInterface, this);
     }
     /**
      * @inheritDoc
      */
     async start() {
-        await this.DataAccount.init();
+        await this._DataAccount.init();
     }
     /**
      * @inheritDoc
      */
     getClaimableDeposits(signer) {
-        return this.DataAccount.getDataAccountsInfo(new web3_js_1.PublicKey(signer));
+        return this._DataAccount.getDataAccountsInfo(new web3_js_1.PublicKey(signer));
     }
     /**
      * @inheritDoc
      */
     claimDeposits(signer) {
-        return this.DataAccount.sweepDataAccounts(signer);
+        return this._DataAccount.sweepDataAccounts(signer);
     }
     ////////////////////////////////////////////
     //// Signatures
@@ -161,13 +166,13 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      * @inheritDoc
      */
     getDataSignature(signer, data) {
-        return this.Chain.Signatures.getDataSignature(signer, data);
+        return this._Chain.Signatures.getDataSignature(signer, data);
     }
     /**
      * @inheritDoc
      */
     isValidDataSignature(data, signature, publicKey) {
-        return this.Chain.Signatures.isValidDataSignature(data, signature, publicKey);
+        return this._Chain.Signatures.isValidDataSignature(data, signature, publicKey);
     }
     ////////////////////////////////////////////
     //// Swap data utils
@@ -186,7 +191,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async isCommited(swapData) {
         const paymentHash = buffer_1.Buffer.from(swapData.paymentHash, "hex");
-        const account = await this.program.account.escrowState.fetchNullable(this.SwapEscrowState(paymentHash));
+        const account = await this.program.account.escrowState.fetchNullable(this._SwapEscrowState(paymentHash));
         if (account == null)
             return false;
         return swapData.correctPDA(account);
@@ -243,7 +248,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      * @inheritDoc
      */
     async getCommitStatus(signer, data) {
-        const escrowStateKey = this.SwapEscrowState(buffer_1.Buffer.from(data.paymentHash, "hex"));
+        const escrowStateKey = this._SwapEscrowState(buffer_1.Buffer.from(data.paymentHash, "hex"));
         const [escrowState, isExpired] = await Promise.all([
             this.program.account.escrowState.fetchNullable(escrowStateKey),
             this.isExpired(signer, data)
@@ -259,7 +264,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
             return { type: base_1.SwapCommitStateType.NOT_COMMITED };
         }
         //Check if paid or what
-        const status = await this.Events.findInEvents(escrowStateKey, async (event, tx) => {
+        const status = await this._Events.findInEvents(escrowStateKey, async (event, tx) => {
             if (event.name === "ClaimEvent") {
                 const paymentHash = buffer_1.Buffer.from(event.data.hash).toString("hex");
                 if (paymentHash !== data.paymentHash)
@@ -321,10 +326,10 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async getClaimHashStatus(claimHash) {
         const { paymentHash } = (0, Utils_1.fromClaimHash)(claimHash);
-        const escrowStateKey = this.SwapEscrowState(buffer_1.Buffer.from(paymentHash, "hex"));
+        const escrowStateKey = this._SwapEscrowState(buffer_1.Buffer.from(paymentHash, "hex"));
         const abortController = new AbortController();
         //Start fetching events before checking escrow PDA, this call is used when quoting, so saving 100ms here helps a lot!
-        const eventsPromise = this.Events.findInEvents(escrowStateKey, async (event) => {
+        const eventsPromise = this._Events.findInEvents(escrowStateKey, async (event) => {
             if (event.name === "ClaimEvent")
                 return base_1.SwapCommitStateType.PAID;
             if (event.name === "RefundEvent")
@@ -352,7 +357,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
     async getCommitedData(claimHashHex) {
         const { paymentHash } = (0, Utils_1.fromClaimHash)(claimHashHex);
         const paymentHashBuffer = buffer_1.Buffer.from(paymentHash, "hex");
-        const account = await this.program.account.escrowState.fetchNullable(this.SwapEscrowState(paymentHashBuffer));
+        const account = await this.program.account.escrowState.fetchNullable(this._SwapEscrowState(paymentHashBuffer));
         if (account == null)
             return null;
         return SolanaSwapData_1.SolanaSwapData.fromEscrowState(account);
@@ -363,7 +368,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
     async getHistoricalSwaps(signer, startBlockheight) {
         let latestBlockheight;
         const events = [];
-        await this.Events.findInEvents(new web3_js_1.PublicKey(signer), async (event, tx) => {
+        await this._Events.findInEvents(new web3_js_1.PublicKey(signer), async (event, tx) => {
             if (latestBlockheight == null)
                 latestBlockheight = tx.slot;
             events.push({ event, tx });
@@ -379,7 +384,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
             if (event.name === "InitializeEvent") {
                 //Parse swap data from initialize event
                 const txoHash = buffer_1.Buffer.from(event.data.txoHash).toString("hex");
-                const instructions = this.Events.decodeInstructions(tx.transaction.message);
+                const instructions = this._Events.decodeInstructions(tx.transaction.message);
                 if (instructions == null) {
                     this.logger.warn(`getHistoricalSwaps(): Skipping tx ${txSignature} because cannot parse instructions!`);
                     continue;
@@ -489,7 +494,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async getBalance(signer, tokenAddress, inContract) {
         if (!inContract) {
-            return await this.Chain.getBalance(signer, tokenAddress);
+            return await this._Chain.getBalance(signer, tokenAddress);
         }
         const token = new web3_js_1.PublicKey(tokenAddress);
         const publicKey = new web3_js_1.PublicKey(signer);
@@ -583,7 +588,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async claimWithSecret(signer, swapData, secret, checkExpiry, initAta, txOptions) {
         const result = await this.Claim.txsClaimWithSecret(signer.getPublicKey(), swapData, secret, checkExpiry, initAta, txOptions?.feeRate);
-        const [signature] = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const [signature] = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
         return signature;
     }
     /**
@@ -593,8 +598,8 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
         if (requiredConfirmations !== swapData.confirmations)
             throw new Error("Invalid requiredConfirmations provided!");
         const { txs, claimTxIndex, storageAcc } = await this.Claim.txsClaimWithTxData(signer, swapData, tx, vout, commitedHeader, synchronizer, initAta, txOptions?.feeRate);
-        const signatures = await this.Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal);
-        await this.DataAccount.removeDataAccount(storageAcc);
+        const signatures = await this._Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        await this._DataAccount.removeDataAccount(storageAcc);
         return signatures[claimTxIndex] ?? signatures[0];
     }
     /**
@@ -602,7 +607,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async refund(signer, swapData, check, initAta, txOptions) {
         let result = await this.txsRefund(signer.getAddress(), swapData, check, initAta, txOptions?.feeRate);
-        const [signature] = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const [signature] = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
         return signature;
     }
     /**
@@ -610,7 +615,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async refundWithAuthorization(signer, swapData, signature, check, initAta, txOptions) {
         let result = await this.txsRefundWithAuthorization(signer.getAddress(), swapData, signature, check, initAta, txOptions?.feeRate);
-        const [txSignature] = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const [txSignature] = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
         return txSignature;
     }
     /**
@@ -626,7 +631,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
                 throw new Error("Invalid signer provided!");
         }
         const result = await this.txsInit(signer.getAddress(), swapData, signature, skipChecks, txOptions?.feeRate);
-        const signatures = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const signatures = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
         return signatures[signatures.length - 1];
     }
     /**
@@ -637,7 +642,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
             throw new Error("Invalid signer provided!");
         const txsCommit = await this.txsInit(signer.getAddress(), swapData, signature, skipChecks, txOptions?.feeRate);
         const txsClaim = await this.Claim.txsClaimWithSecret(signer.getPublicKey(), swapData, secret, true, false, txOptions?.feeRate, true);
-        const signatures = await this.Chain.sendAndConfirm(signer, txsCommit.concat(txsClaim), txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const signatures = await this._Chain.sendAndConfirm(signer, txsCommit.concat(txsClaim), txOptions?.waitForConfirmation, txOptions?.abortSignal);
         return [signatures[txsCommit.length - 1], signatures[signatures.length - 1]];
     }
     /**
@@ -645,7 +650,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async withdraw(signer, token, amount, txOptions) {
         const txs = await this.LpVault.txsWithdraw(signer.getPublicKey(), new web3_js_1.PublicKey(token), amount, txOptions?.feeRate);
-        const [txId] = await this.Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
+        const [txId] = await this._Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
         return txId;
     }
     /**
@@ -653,7 +658,7 @@ class SolanaSwapProgram extends SolanaProgramBase_1.SolanaProgramBase {
      */
     async deposit(signer, token, amount, txOptions) {
         const txs = await this.LpVault.txsDeposit(signer.getPublicKey(), new web3_js_1.PublicKey(token), amount, txOptions?.feeRate);
-        const [txId] = await this.Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
+        const [txId] = await this._Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
         return txId;
     }
     ////////////////////////////////////////////

--- a/dist/solana/swaps/modules/SolanaDataAccount.js
+++ b/dist/solana/swaps/modules/SolanaDataAccount.js
@@ -96,8 +96,8 @@ class SolanaDataAccount extends SolanaSwapModule_1.SolanaSwapModule {
     }
     constructor(chainInterface, program, storage) {
         super(chainInterface, program);
-        this.SwapTxDataAlt = this.program.keypair((reversedTxId, signer) => [Buffer.from(signer.secretKey), reversedTxId]);
-        this.SwapTxDataAltBuffer = this.program.keypair((reversedTxId, secret) => [secret, reversedTxId]);
+        this.SwapTxDataAlt = this.program._keypair((reversedTxId, signer) => [Buffer.from(signer.secretKey), reversedTxId]);
+        this.SwapTxDataAltBuffer = this.program._keypair((reversedTxId, secret) => [secret, reversedTxId]);
         this.storage = storage;
     }
     /**

--- a/dist/solana/swaps/modules/SolanaLpVault.js
+++ b/dist/solana/swaps/modules/SolanaLpVault.js
@@ -23,9 +23,9 @@ class SolanaLpVault extends SolanaSwapModule_1.SolanaSwapModule {
             .accounts({
             signer,
             signerAta: ata,
-            userData: this.program.SwapUserVault(signer, token),
-            vault: this.program.SwapVault(token),
-            vaultAuthority: this.program.SwapVaultAuthority,
+            userData: this.program._SwapUserVault(signer, token),
+            vault: this.program._SwapVault(token),
+            vaultAuthority: this.program._SwapVaultAuthority,
             mint: token,
             tokenProgram: spl_token_1.TOKEN_PROGRAM_ID
         })
@@ -46,9 +46,9 @@ class SolanaLpVault extends SolanaSwapModule_1.SolanaSwapModule {
             .accounts({
             signer,
             signerAta: ata,
-            userData: this.program.SwapUserVault(signer, token),
-            vault: this.program.SwapVault(token),
-            vaultAuthority: this.program.SwapVaultAuthority,
+            userData: this.program._SwapUserVault(signer, token),
+            vault: this.program._SwapVault(token),
+            vaultAuthority: this.program._SwapVaultAuthority,
             mint: token,
             systemProgram: web3_js_1.SystemProgram.programId,
             tokenProgram: spl_token_1.TOKEN_PROGRAM_ID
@@ -62,7 +62,7 @@ class SolanaLpVault extends SolanaSwapModule_1.SolanaSwapModule {
      * @param token
      */
     async getIntermediaryData(address, token) {
-        const data = await this.swapProgram.account.userAccount.fetchNullable(this.program.SwapUserVault(address, token));
+        const data = await this.swapProgram.account.userAccount.fetchNullable(this.program._SwapUserVault(address, token));
         if (data == null)
             return null;
         const response = [];
@@ -159,8 +159,8 @@ class SolanaLpVault extends SolanaSwapModule_1.SolanaSwapModule {
         return this.root.Fees.getFeeRate([
             signer,
             ata,
-            this.program.SwapUserVault(signer, token),
-            this.program.SwapVault(token)
+            this.program._SwapUserVault(signer, token),
+            this.program._SwapVault(token)
         ]);
     }
 }

--- a/dist/solana/swaps/modules/SwapClaim.js
+++ b/dist/solana/swaps/modules/SwapClaim.js
@@ -15,7 +15,7 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
         const accounts = {
             signer,
             initializer: swapData.isPayIn() ? swapData.offerer : swapData.claimer,
-            escrowState: this.program.SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")),
+            escrowState: this.program._SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")),
             ixSysvar: web3_js_1.SYSVAR_INSTRUCTIONS_PUBKEY,
             data: isDataKey ? secretOrDataKey : null,
         };
@@ -28,8 +28,8 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
                 .accounts({
                 ...accounts,
                 claimerAta: swapData.claimerAta,
-                vault: this.program.SwapVault(swapData.token),
-                vaultAuthority: this.program.SwapVaultAuthority,
+                vault: this.program._SwapVault(swapData.token),
+                vaultAuthority: this.program._SwapVaultAuthority,
                 tokenProgram: spl_token_1.TOKEN_PROGRAM_ID
             })
                 .instruction(), this.getComputeBudget(swapData));
@@ -39,7 +39,7 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
                 .claimerClaim(secretBuffer)
                 .accounts({
                 ...accounts,
-                claimerUserData: this.program.SwapUserVault(swapData.claimer, swapData.token)
+                claimerUserData: this.program._SwapUserVault(swapData.claimer, swapData.token)
             })
                 .instruction(), this.getComputeBudget(swapData));
         }
@@ -133,7 +133,7 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
             Buffer.from(tx.hex, "hex")
         ]);
         this.logger.debug("addTxsWriteTransactionData(): writing transaction data: ", writeData.toString("hex"));
-        return this.program.DataAccount.addTxsWriteData(signer, reversedTxId, writeData, txs, feeRate);
+        return this.program._DataAccount.addTxsWriteData(signer, reversedTxId, writeData, txs, feeRate);
     }
     /**
      * Checks whether we should unwrap the WSOL to SOL when claiming the swap
@@ -206,7 +206,7 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
         const signerKey = signer instanceof SolanaSigner_1.SolanaSigner ? signer.getPublicKey() : signer;
         if (feeRate == null)
             feeRate = await this.getClaimFeeRate(signerKey, swapData);
-        const merkleProof = await this.btcRelay.bitcoinRpc.getMerkleProof(tx.txid, tx.blockhash);
+        const merkleProof = await this.btcRelay._bitcoinRpc.getMerkleProof(tx.txid, tx.blockhash);
         if (merkleProof == null)
             throw new Error(`Failed to generate merkle proof for tx: ${tx.txid}`);
         this.logger.debug("txsClaimWithTxData(): merkle proof computed: ", merkleProof);
@@ -236,7 +236,7 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
         const accounts = [signer];
         if (swapData.payOut) {
             if (swapData.token != null)
-                accounts.push(this.program.SwapVault(swapData.token));
+                accounts.push(this.program._SwapVault(swapData.token));
             if (swapData.payIn) {
                 if (swapData.offerer != null)
                     accounts.push(swapData.offerer);
@@ -250,7 +250,7 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
         }
         else {
             if (swapData.claimer != null && swapData.token != null)
-                accounts.push(this.program.SwapUserVault(swapData.claimer, swapData.token));
+                accounts.push(this.program._SwapUserVault(swapData.claimer, swapData.token));
             if (swapData.payIn) {
                 if (swapData.offerer != null)
                     accounts.push(swapData.offerer);
@@ -261,7 +261,7 @@ class SwapClaim extends SolanaSwapModule_1.SolanaSwapModule {
             }
         }
         if (swapData.paymentHash != null)
-            accounts.push(this.program.SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")));
+            accounts.push(this.program._SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")));
         return this.root.Fees.getFeeRate(accounts);
     }
     /**

--- a/dist/solana/swaps/modules/SwapInit.js
+++ b/dist/solana/swaps/modules/SwapInit.js
@@ -166,7 +166,7 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
         if (preFetchedData != null &&
             preFetchedData.latestSlot != null &&
             preFetchedData.latestSlot.timestamp > Date.now() - this.root.Slots.SLOT_CACHE_TIME) {
-            const estimatedSlotsPassed = Math.floor((Date.now() - preFetchedData.latestSlot.timestamp) / this.root.SLOT_TIME);
+            const estimatedSlotsPassed = Math.floor((Date.now() - preFetchedData.latestSlot.timestamp) / this.root._SLOT_TIME);
             const estimatedCurrentSlot = preFetchedData.latestSlot.slot + estimatedSlotsPassed;
             this.logger.debug("getSlotForSignature(): slot: " + preFetchedData.latestSlot.slot +
                 " estimated passed slots: " + estimatedSlotsPassed + " estimated current slot: " + estimatedCurrentSlot);
@@ -291,7 +291,7 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
             this.getSlotForSignature(preFetchedData),
             this.getBlockhashForSignature(txSlot, preFetchedData)
         ]);
-        const lastValidTransactionSlot = txSlot + this.root.TX_SLOT_VALIDITY;
+        const lastValidTransactionSlot = txSlot + this.root._TX_SLOT_VALIDITY;
         const slotsLeft = lastValidTransactionSlot - latestSlot - this.SIGNATURE_SLOT_BUFFER;
         if (slotsLeft < 0)
             throw new base_1.SignatureVerificationError("Authorization expired!");
@@ -317,10 +317,10 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
         const [transactionSlotStr, signatureString] = signature.split(";");
         const txSlot = parseInt(transactionSlotStr);
         const latestSlot = await this.getSlotForSignature(preFetchedData);
-        const lastValidTransactionSlot = txSlot + this.root.TX_SLOT_VALIDITY;
+        const lastValidTransactionSlot = txSlot + this.root._TX_SLOT_VALIDITY;
         const slotsLeft = lastValidTransactionSlot - latestSlot - this.SIGNATURE_SLOT_BUFFER;
         const now = Date.now();
-        const slotExpiryTime = now + (slotsLeft * this.root.SLOT_TIME);
+        const slotExpiryTime = now + (slotsLeft * this.root._SLOT_TIME);
         const timeoutExpiryTime = (parseInt(timeout) - this.program._authGracePeriod) * 1000;
         const expiry = Math.min(slotExpiryTime, timeoutExpiryTime);
         if (expiry < now)
@@ -337,7 +337,7 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
     async isSignatureExpired(signature, timeout) {
         const [transactionSlotStr, signatureString] = signature.split(";");
         const txSlot = parseInt(transactionSlotStr);
-        const lastValidTransactionSlot = txSlot + this.root.TX_SLOT_VALIDITY;
+        const lastValidTransactionSlot = txSlot + this.root._TX_SLOT_VALIDITY;
         const latestSlot = await this.root.Slots.getSlot("finalized");
         const slotsLeft = lastValidTransactionSlot - latestSlot + this.SIGNATURE_SLOT_BUFFER;
         if (slotsLeft < 0)

--- a/dist/solana/swaps/modules/SwapInit.js
+++ b/dist/solana/swaps/modules/SwapInit.js
@@ -28,11 +28,11 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
         const accounts = {
             claimer: swapData.claimer,
             offerer: swapData.offerer,
-            escrowState: this.program.SwapEscrowState(paymentHash),
+            escrowState: this.program._SwapEscrowState(paymentHash),
             mint: swapData.token,
             systemProgram: web3_js_1.SystemProgram.programId,
             claimerAta: swapData.payOut ? claimerAta : null,
-            claimerUserData: !swapData.payOut ? this.program.SwapUserVault(swapData.claimer, swapData.token) : null
+            claimerUserData: !swapData.payOut ? this.program._SwapUserVault(swapData.claimer, swapData.token) : null
         };
         if (swapData.payIn) {
             const ata = (0, spl_token_1.getAssociatedTokenAddressSync)(swapData.token, swapData.offerer);
@@ -41,8 +41,8 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
                 .accounts({
                 ...accounts,
                 offererAta: ata,
-                vault: this.program.SwapVault(swapData.token),
-                vaultAuthority: this.program.SwapVaultAuthority,
+                vault: this.program._SwapVault(swapData.token),
+                vaultAuthority: this.program._SwapVaultAuthority,
                 tokenProgram: spl_token_1.TOKEN_PROGRAM_ID,
             })
                 .instruction(), SwapInit.CUCosts.INIT_PAY_IN);
@@ -52,7 +52,7 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
                 .offererInitialize(swapData.toSwapDataStruct(), swapData.securityDeposit, swapData.claimerBounty, [...(swapData.txoHash != null ? buffer_1.Buffer.from(swapData.txoHash, "hex") : buffer_1.Buffer.alloc(32, 0))], (0, Utils_1.toBN)(timeout))
                 .accounts({
                 ...accounts,
-                offererUserData: this.program.SwapUserVault(swapData.offerer, swapData.token),
+                offererUserData: this.program._SwapUserVault(swapData.offerer, swapData.token),
             })
                 .instruction(), SwapInit.CUCosts.INIT);
         }
@@ -282,7 +282,7 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
         if (prefix !== this.getAuthPrefix(swapData))
             throw new base_1.SignatureVerificationError("Invalid prefix");
         const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
-        const isExpired = (BigInt(timeout) - currentTimestamp) < BigInt(this.program.authGracePeriod);
+        const isExpired = (BigInt(timeout) - currentTimestamp) < BigInt(this.program._authGracePeriod);
         if (isExpired)
             throw new base_1.SignatureVerificationError("Authorization expired!");
         const [transactionSlot, signatureString] = signature.split(";");
@@ -321,7 +321,7 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
         const slotsLeft = lastValidTransactionSlot - latestSlot - this.SIGNATURE_SLOT_BUFFER;
         const now = Date.now();
         const slotExpiryTime = now + (slotsLeft * this.root.SLOT_TIME);
-        const timeoutExpiryTime = (parseInt(timeout) - this.program.authGracePeriod) * 1000;
+        const timeoutExpiryTime = (parseInt(timeout) - this.program._authGracePeriod) * 1000;
         const expiry = Math.min(slotExpiryTime, timeoutExpiryTime);
         if (expiry < now)
             return 0;
@@ -342,7 +342,7 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
         const slotsLeft = lastValidTransactionSlot - latestSlot + this.SIGNATURE_SLOT_BUFFER;
         if (slotsLeft < 0)
             return true;
-        if ((parseInt(timeout) + this.program.authGracePeriod) * 1000 < Date.now())
+        if ((parseInt(timeout) + this.program._authGracePeriod) * 1000 < Date.now())
             return true;
         return false;
     }
@@ -427,14 +427,14 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
         if (offerer != null)
             accounts.push(offerer);
         if (token != null) {
-            accounts.push(this.program.SwapVault(token));
+            accounts.push(this.program._SwapVault(token));
             if (offerer != null)
                 accounts.push((0, spl_token_1.getAssociatedTokenAddressSync)(token, offerer));
             if (claimer != null)
-                accounts.push(this.program.SwapUserVault(claimer, token));
+                accounts.push(this.program._SwapUserVault(claimer, token));
         }
         if (paymentHash != null)
-            accounts.push(this.program.SwapEscrowState(buffer_1.Buffer.from(paymentHash, "hex")));
+            accounts.push(this.program._SwapEscrowState(buffer_1.Buffer.from(paymentHash, "hex")));
         const shouldCheckWSOLAta = token != null && offerer != null && token.equals(SolanaTokens_1.SolanaTokens.WSOL_ADDRESS);
         let [feeRate, account] = await Promise.all([
             this.root.Fees.getFeeRate(accounts),
@@ -461,11 +461,11 @@ class SwapInit extends SolanaSwapModule_1.SolanaSwapModule {
     getInitFeeRate(offerer, claimer, token, paymentHash) {
         const accounts = [];
         if (offerer != null && token != null)
-            accounts.push(this.program.SwapUserVault(offerer, token));
+            accounts.push(this.program._SwapUserVault(offerer, token));
         if (claimer != null)
             accounts.push(claimer);
         if (paymentHash != null)
-            accounts.push(this.program.SwapEscrowState(buffer_1.Buffer.from(paymentHash, "hex")));
+            accounts.push(this.program._SwapEscrowState(buffer_1.Buffer.from(paymentHash, "hex")));
         return this.root.Fees.getFeeRate(accounts);
     }
     /**

--- a/dist/solana/swaps/modules/SwapRefund.js
+++ b/dist/solana/swaps/modules/SwapRefund.js
@@ -24,8 +24,8 @@ class SwapRefund extends SolanaSwapModule_1.SolanaSwapModule {
         const accounts = {
             offerer: swapData.offerer,
             claimer: swapData.claimer,
-            escrowState: this.program.SwapEscrowState(buffer_1.Buffer.from(swapData.paymentHash, "hex")),
-            claimerUserData: !swapData.payOut ? this.program.SwapUserVault(swapData.claimer, swapData.token) : null,
+            escrowState: this.program._SwapEscrowState(buffer_1.Buffer.from(swapData.paymentHash, "hex")),
+            claimerUserData: !swapData.payOut ? this.program._SwapUserVault(swapData.claimer, swapData.token) : null,
             ixSysvar: refundAuthTimeout != null ? web3_js_1.SYSVAR_INSTRUCTIONS_PUBKEY : null
         };
         const useTimeout = refundAuthTimeout != null ? refundAuthTimeout : 0n;
@@ -36,8 +36,8 @@ class SwapRefund extends SolanaSwapModule_1.SolanaSwapModule {
                 .accounts({
                 ...accounts,
                 offererAta: ata,
-                vault: this.program.SwapVault(swapData.token),
-                vaultAuthority: this.program.SwapVaultAuthority,
+                vault: this.program._SwapVault(swapData.token),
+                vaultAuthority: this.program._SwapVaultAuthority,
                 tokenProgram: spl_token_1.TOKEN_PROGRAM_ID
             })
                 .instruction(), SwapRefund.CUCosts.REFUND_PAY_OUT);
@@ -47,7 +47,7 @@ class SwapRefund extends SolanaSwapModule_1.SolanaSwapModule {
                 .offererRefund((0, Utils_1.toBN)(useTimeout))
                 .accounts({
                 ...accounts,
-                offererUserData: this.program.SwapUserVault(swapData.offerer, swapData.token)
+                offererUserData: this.program._SwapUserVault(swapData.offerer, swapData.token)
             })
                 .instruction(), SwapRefund.CUCosts.REFUND);
         }
@@ -120,7 +120,7 @@ class SwapRefund extends SolanaSwapModule_1.SolanaSwapModule {
             throw new base_1.SignatureVerificationError("Invalid prefix");
         const expiryTimestamp = BigInt(timeout);
         const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
-        const isExpired = (expiryTimestamp - currentTimestamp) < BigInt(this.program.authGracePeriod);
+        const isExpired = (expiryTimestamp - currentTimestamp) < BigInt(this.program._authGracePeriod);
         if (isExpired)
             throw new base_1.SignatureVerificationError("Authorization expired!");
         const signatureBuffer = buffer_1.Buffer.from(signature, "hex");
@@ -230,7 +230,7 @@ class SwapRefund extends SolanaSwapModule_1.SolanaSwapModule {
         const accounts = [];
         if (swapData.payIn) {
             if (swapData.token != null)
-                accounts.push(this.program.SwapVault(swapData.token));
+                accounts.push(this.program._SwapVault(swapData.token));
             if (swapData.offerer != null)
                 accounts.push(swapData.offerer);
             if (swapData.claimer != null)
@@ -242,13 +242,13 @@ class SwapRefund extends SolanaSwapModule_1.SolanaSwapModule {
             if (swapData.offerer != null) {
                 accounts.push(swapData.offerer);
                 if (swapData.token != null)
-                    accounts.push(this.program.SwapUserVault(swapData.offerer, swapData.token));
+                    accounts.push(this.program._SwapUserVault(swapData.offerer, swapData.token));
             }
             if (swapData.claimer != null)
                 accounts.push(swapData.claimer);
         }
         if (swapData.paymentHash != null)
-            accounts.push(this.program.SwapEscrowState(buffer_1.Buffer.from(swapData.paymentHash, "hex")));
+            accounts.push(this.program._SwapEscrowState(buffer_1.Buffer.from(swapData.paymentHash, "hex")));
         return this.root.Fees.getFeeRate(accounts);
     }
     /**

--- a/dist/solana/wallet/SolanaKeypairWallet.d.ts
+++ b/dist/solana/wallet/SolanaKeypairWallet.d.ts
@@ -5,9 +5,25 @@ import { Keypair, PublicKey, Transaction, VersionedTransaction } from "@solana/w
  * @category Wallets
  */
 export declare class SolanaKeypairWallet implements Wallet {
+    /**
+     * Underlying signer keypair.
+     */
     readonly payer: Keypair;
     constructor(payer: Keypair);
+    /**
+     * Public key of the wrapped payer keypair.
+     */
     get publicKey(): PublicKey;
+    /**
+     * Signs all provided transactions with the wrapped keypair.
+     *
+     * @param txs Transactions to sign
+     */
     signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]>;
+    /**
+     * Signs a single transaction with the wrapped keypair.
+     *
+     * @param tx Transaction to sign
+     */
     signTransaction<T extends Transaction | VersionedTransaction>(tx: T): Promise<T>;
 }

--- a/dist/solana/wallet/SolanaKeypairWallet.js
+++ b/dist/solana/wallet/SolanaKeypairWallet.js
@@ -10,9 +10,17 @@ class SolanaKeypairWallet {
     constructor(payer) {
         this.payer = payer;
     }
+    /**
+     * Public key of the wrapped payer keypair.
+     */
     get publicKey() {
         return this.payer.publicKey;
     }
+    /**
+     * Signs all provided transactions with the wrapped keypair.
+     *
+     * @param txs Transactions to sign
+     */
     signAllTransactions(txs) {
         txs.forEach((tx) => {
             if (tx instanceof web3_js_1.Transaction) {
@@ -24,6 +32,11 @@ class SolanaKeypairWallet {
         });
         return Promise.resolve(txs);
     }
+    /**
+     * Signs a single transaction with the wrapped keypair.
+     *
+     * @param tx Transaction to sign
+     */
     signTransaction(tx) {
         if (tx instanceof web3_js_1.Transaction) {
             tx.partialSign(this.payer);

--- a/dist/solana/wallet/SolanaSigner.d.ts
+++ b/dist/solana/wallet/SolanaSigner.d.ts
@@ -6,10 +6,22 @@ import { PublicKey, Signer } from "@solana/web3.js";
  * @category Wallets
  */
 export declare class SolanaSigner implements AbstractSigner {
+    /**
+     * @inheritDoc
+     */
     type: "AtomiqAbstractSigner";
+    /**
+     * Wrapped wallet implementation used for signing.
+     */
     wallet: Wallet;
+    /**
+     * Optional raw keypair signer when available.
+     */
     keypair?: Signer;
     constructor(wallet: Wallet, keypair?: Signer);
+    /**
+     * Returns public key of the wrapped wallet.
+     */
     getPublicKey(): PublicKey;
     /**
      * @inheritDoc

--- a/dist/solana/wallet/SolanaSigner.js
+++ b/dist/solana/wallet/SolanaSigner.js
@@ -7,10 +7,16 @@ exports.SolanaSigner = void 0;
  */
 class SolanaSigner {
     constructor(wallet, keypair) {
+        /**
+         * @inheritDoc
+         */
         this.type = "AtomiqAbstractSigner";
         this.wallet = wallet;
         this.keypair = keypair;
     }
+    /**
+     * Returns public key of the wrapped wallet.
+     */
     getPublicKey() {
         return this.wallet.publicKey;
     }

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -1,0 +1,1 @@
+export * from "../dist/node";

--- a/node/index.js
+++ b/node/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("../dist/node");

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "files": [
     "/dist",
-    "/src"
+    "/src",
+    "/node"
   ],
   "keywords": [
     "Solana",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@coral-xyz/anchor": "0.29.0",
     "@noble/hashes": "^1.7.1",
     "@solana/spl-token": "0.4.14",
-    "bn.js": "5.2.1",
+    "bn.js": "5.2.3",
     "bs58": "^4.0.1",
     "buffer": "6.0.3",
     "tweetnacl": "1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/chain-solana",
-  "version": "13.0.11",
+  "version": "13.1.0",
   "description": "Solana specific base implementation",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export * from "./solana/btcrelay/SolanaBtcRelay";
 export * from "./solana/chain/SolanaChainInterface";
 export * from "./solana/chain/modules/SolanaFees";
 
+export {ConnectionWithRetries} from "./solana/connection/ConnectionWithRetries";
+
 export * from "./solana/events/SolanaChainEventsBrowser";
 
 export * from "./solana/swaps/SolanaSwapProgram";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export * from "./solana/chain/modules/SolanaFees";
 
 export {ConnectionWithRetries} from "./solana/connection/ConnectionWithRetries";
 
-export * from "./solana/events/SolanaChainEventsBrowser";
+export {SolanaChainEventsBrowser, SolanaEventListenerState} from "./solana/events/SolanaChainEventsBrowser";
 
 export * from "./solana/swaps/SolanaSwapProgram";
 export {SolanaSwapData} from "./solana/swaps/SolanaSwapData";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,70 @@
+/**
+ * # @atomiqlabs/chain-solana
+ *
+ * `@atomiqlabs/chain-solana` is the Solana integration package for the Atomiq protocol.
+ *
+ * Within the Atomiq stack, this library provides the Solana-side building blocks used for Bitcoin-aware swaps on Solana. It includes:
+ *
+ * - the `SolanaInitializer` used to register Solana support in the Atomiq SDK
+ * - the `SolanaChainInterface` used to talk to Solana RPCs
+ * - Solana BTC relay and swap program wrappers
+ * - signer and wallet helpers for Solana integrations
+ * - connection retry and chain event utilities
+ *
+ * This package is intended for direct protocol integrations and for higher-level Atomiq SDK layers that need Solana chain support.
+ *
+ * ## Installation
+ *
+ * Install the package with its `@solana/web3.js` peer dependency:
+ *
+ * ```bash
+ * npm install @atomiqlabs/chain-solana @solana/web3.js
+ * ```
+ *
+ * ## Supported Chains
+ *
+ * This package exports a single Solana initializer:
+ *
+ * - Solana via `SolanaInitializer`
+ *
+ * Canonical deployments currently defined in this package:
+ *
+ * | Chain | Canonical deployments included |
+ * | --- | --- |
+ * | Solana | `MAINNET`, `TESTNET` |
+ *
+ * In this package, the selected Bitcoin network determines which canonical Solana program addresses are used by default. `BitcoinNetwork.TESTNET4` is not wired to a Solana deployment here yet.
+ *
+ * The Solana implementation doesn't support the UTXO-controlled vault (SPV vault) contract, hence it can only process legacy HTLC & PrTLC based swaps.
+ *
+ * ## SDK Example
+ *
+ * Initialize the Atomiq SDK with Solana network support:
+ *
+ * ```ts
+ * import {SolanaInitializer} from "@atomiqlabs/chain-solana";
+ * import {BitcoinNetwork, SwapperFactory, TypedSwapper} from "@atomiqlabs/sdk";
+ *
+ * // Define chains that you want to support here
+ * const chains = [SolanaInitializer] as const;
+ * type SupportedChains = typeof chains;
+ *
+ * const Factory = new SwapperFactory<SupportedChains>(chains);
+ *
+ * const swapper: TypedSwapper<SupportedChains> = Factory.newSwapper({
+ *   chains: {
+ *     SOLANA: {
+ *       rpcUrl: solanaRpc // You can also pass a web3.js Connection object here
+ *     }
+ *   },
+ *   bitcoinNetwork: BitcoinNetwork.MAINNET // or BitcoinNetwork.TESTNET
+ * });
+ * ```
+ *
+ * If you use the lower-level initializer directly, you can also provide a custom storage backend for temporary Solana data accounts used when submitting large Bitcoin proof payloads.
+ *
+ * @packageDocumentation
+ */
 export {SolanaBtcHeader} from "./solana/btcrelay/headers/SolanaBtcHeader";
 export {SolanaBtcStoredHeader} from "./solana/btcrelay/headers/SolanaBtcStoredHeader";
 export * from "./solana/btcrelay/SolanaBtcRelay";

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export * from "./solana/btcrelay/SolanaBtcRelay";
 
 export * from "./solana/chain/SolanaChainInterface";
 export * from "./solana/chain/modules/SolanaFees";
+export {SolanaTx, SignedSolanaTx} from "./solana/chain/modules/SolanaTransactions";
 
 export {ConnectionWithRetries} from "./solana/connection/ConnectionWithRetries";
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Node.js-only entrypoint for filesystem-backed Solana helpers.
+ *
+ * Import from `@atomiqlabs/chain-solana/node` when you need runtime features
+ * that depend on Node's `fs` module.
+ *
+ * @packageDocumentation
+ */
+export {SolanaChainEvents} from "../solana/events/SolanaChainEvents";

--- a/src/solana/SolanaInitializer.ts
+++ b/src/solana/SolanaInitializer.ts
@@ -53,18 +53,46 @@ const SolanaAssets: SolanaAssetsType = {
  * @category Chain Interface
  */
 export type SolanaSwapperOptions = {
+    /**
+     * RPC url or {@link Connection} object to use for Solana network access
+     */
     rpcUrl: string | Connection,
+    /**
+     * Storage backend to use for storing ephemeral data submission accounts, i.e. accounts that are used
+     *  to submit large amount of data to an instruction that would otherwise be bigger than the transaction
+     *  size limit - used for submitting bitcoin transaction proofs for PrTLC swaps
+     */
     dataAccountStorage?: IStorageManager<StoredDataAccount>,
+    /**
+     * Retry policy to be used for Solana RPC calls and transaction submission
+     */
     retryPolicy?: SolanaRetryPolicy,
 
+    /**
+     * Optional Solana program address of the BTC Relay contract, uses the canonical deployment by default
+     */
     btcRelayContract?: string,
+    /**
+     * Optional Solana program address of the Swap contract, uses the canonical deployment by default
+     */
     swapContract?: string,
 
+    /**
+     * Solana fee API to use for fetching Solana network fees
+     */
     fees?: SolanaFees
 };
 
 /**
  * Initialize Solana chain integration
+ *
+ * @param options Options for initializing the Solana chain
+ * @param bitcoinRpc Bitcoin RPC to use for bitcoin read access
+ * @param network Bitcoin network to use - determines Solana program addresses to use by default
+ * @param storageCtor Storage constructor used to create storage backend for ephemeral data submission accounts,
+ *  i.e. accounts that are used to submit large amount of data to an instruction that would otherwise be bigger
+ *  than the transaction size limit - used for submitting bitcoin transaction proofs for PrTLC swaps
+ *
  * @category Chain Interface
  */
 export function initializeSolana(
@@ -109,12 +137,14 @@ export function initializeSolana(
 
 /**
  * Type definition for the Solana chain initializer
+ *
  * @category Chain Interface
  */
 export type SolanaInitializerType = ChainInitializer<SolanaSwapperOptions, SolanaChainType, SolanaAssetsType>;
 
 /**
- * Solana chain initializer instance
+ * Solana chain initializer instance, used in the SwapperFactory constructor in the SDK library
+ *
  * @category Chain Interface
  */
 export const SolanaInitializer: SolanaInitializerType = {

--- a/src/solana/btcrelay/SolanaBtcRelay.ts
+++ b/src/solana/btcrelay/SolanaBtcRelay.ts
@@ -63,7 +63,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
                 .accounts({
                     signer,
                     mainState: this.BtcRelayMainState,
-                    headerTopic: this.BtcRelayHeader(serializedBlock.hash),
+                    headerTopic: this.BtcRelayHeader(serializedBlock.getHash()),
                     systemProgram: SystemProgram.programId
                 })
                 .instruction(),
@@ -118,7 +118,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
      * @param signer Signer paying and receiving rent refund
      * @param forkId Fork account identifier to close
      */
-    public async CloseForkAccount(signer: PublicKey, forkId: number): Promise<SolanaAction> {
+    private async CloseForkAccount(signer: PublicKey, forkId: number): Promise<SolanaAction> {
         return new SolanaAction(signer, this.Chain,
             await this.program.methods
                 .closeForkAccount(
@@ -137,15 +137,15 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
     /**
      * PDA of the relay main state account.
      */
-    BtcRelayMainState = this.pda("state");
+    private readonly BtcRelayMainState = this.pda("state");
     /**
      * PDA helper for per-header topic accounts.
      */
-    BtcRelayHeader = this.pda("header", (hash: Buffer) => [hash]);
+    private readonly BtcRelayHeader = this.pda("header", (hash: Buffer) => [hash]);
     /**
      * PDA helper for fork state accounts.
      */
-    BtcRelayFork = this.pda("fork",
+    private readonly BtcRelayFork = this.pda("fork",
         (forkId: number, pubkey: PublicKey) => [new BN(forkId).toArrayLike(Buffer, "le", 8), pubkey.toBuffer()]
     );
 
@@ -230,7 +230,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         const tx = await createTx(blockHeaderObj)
             .remainingAccounts(blockHeaderObj.map(e => {
                 return {
-                    pubkey: this.BtcRelayHeader(e.hash),
+                    pubkey: this.BtcRelayHeader(e.getHash()),
                     isSigner: false,
                     isWritable: false
                 }
@@ -321,7 +321,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
             }
         });
         if(data!=null) this.logger.debug("retrieveLogByCommitHash(): block found," +
-            " commit hash: "+commitmentHashStr+" blockhash: "+blockData.blockhash+" height: "+data.blockheight);
+            " commit hash: "+commitmentHashStr+" blockhash: "+blockData.blockhash+" height: "+data.getBlockheight());
 
         return data;
     }
@@ -357,7 +357,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
 
         if(data!=null) this.logger.debug("retrieveLatestKnownBlockLog(): block found," +
             " commit hash: "+data.commitHash+" blockhash: "+data.resultBitcoinHeader.getHash()+
-            " height: "+data.resultStoredHeader.blockheight);
+            " height: "+data.resultStoredHeader.getBlockheight());
 
         return data;
     }
@@ -431,7 +431,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
                 })
         );
 
-        if(result.forkId!==0 && StatePredictorUtils.gtBuffer(Buffer.from(result.lastStoredHeader.chainWork), tipWork)) {
+        if(result.forkId!==0 && StatePredictorUtils.gtBuffer(result.lastStoredHeader.getChainWork(), tipWork)) {
             //Fork's work is higher than main chain's work, this fork will become a main chain
             result.forkId = 0;
         }
@@ -466,7 +466,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
                 })
         );
 
-        if(result.forkId!==0 && StatePredictorUtils.gtBuffer(Buffer.from(result.lastStoredHeader.chainWork), tipWork)) {
+        if(result.forkId!==0 && StatePredictorUtils.gtBuffer(result.lastStoredHeader.getChainWork(), tipWork)) {
             //Fork's work is higher than main chain's work, this fork will become a main chain
             result.forkId = 0;
         }
@@ -497,7 +497,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
                 })
         );
 
-        if(result.forkId!==0 && StatePredictorUtils.gtBuffer(Buffer.from(result.lastStoredHeader.chainWork), tipWork)) {
+        if(result.forkId!==0 && StatePredictorUtils.gtBuffer(result.lastStoredHeader.getChainWork(), tipWork)) {
             //Fork's work is higher than main chain's work, this fork will become a main chain
             result.forkId = 0;
         }

--- a/src/solana/btcrelay/SolanaBtcRelay.ts
+++ b/src/solana/btcrelay/SolanaBtcRelay.ts
@@ -1,5 +1,4 @@
 import {
-    Connection,
     PublicKey,
     Signer,
     SystemProgram,
@@ -17,7 +16,7 @@ import {SolanaTx} from "../chain/modules/SolanaTransactions";
 import {SolanaSigner} from "../wallet/SolanaSigner";
 import * as BN from "bn.js";
 import {SolanaChainInterface} from "../chain/SolanaChainInterface";
-import {getLogger} from "../../utils/Utils";
+import {SolanaFees} from "../chain/modules/SolanaFees";
 
 const MAX_CLOSE_IX_PER_TX = 10;
 
@@ -51,7 +50,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
      */
     private async Initialize(signer: PublicKey, header: B, epochStart: number, pastBlocksTimestamps: number[]): Promise<SolanaAction> {
         const serializedBlock = serializeBlockHeader(header);
-        return new SolanaAction(signer, this.Chain,
+        return new SolanaAction(signer, this._Chain,
             await this.program.methods
                 .initialize(
                     serializedBlock,
@@ -91,7 +90,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         reversedMerkleProof: Buffer[],
         committedHeader: SolanaBtcStoredHeader
     ): Promise<SolanaAction> {
-        return new SolanaAction(signer, this.Chain,
+        return new SolanaAction(signer, this._Chain,
             await this.program.methods
                 .verifyTransaction(
                     reversedTxId,
@@ -119,7 +118,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
      * @param forkId Fork account identifier to close
      */
     private async CloseForkAccount(signer: PublicKey, forkId: number): Promise<SolanaAction> {
-        return new SolanaAction(signer, this.Chain,
+        return new SolanaAction(signer, this._Chain,
             await this.program.methods
                 .closeForkAccount(
                     new BN(forkId)
@@ -151,8 +150,10 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
 
     /**
      * Bitcoin RPC client used for bitcoin chain lookups.
+     *
+     * @internal
      */
-    bitcoinRpc: BitcoinRpc<B>;
+    _bitcoinRpc: BitcoinRpc<B>;
 
     /**
      * @inheritDoc
@@ -167,13 +168,18 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
      */
     readonly maxShortForkHeadersPerTx: number = 4;
 
+    /**
+     * @param chainInterface Underlying chain interface to use for the Solana chain operations
+     * @param bitcoinRpc Bitcoin RPC instance to use for read access to the bitcoin blockchain
+     * @param programAddress Optional Solana on-chain program address, defaults to the cannonical deployment
+     */
     constructor(
         chainInterface: SolanaChainInterface,
         bitcoinRpc: BitcoinRpc<B>,
         programAddress?: string
     ) {
         super(chainInterface, programIdl, programAddress);
-        this.bitcoinRpc = bitcoinRpc;
+        this._bitcoinRpc = bitcoinRpc;
     }
 
     /**
@@ -238,8 +244,8 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
             .transaction();
         tx.feePayer = signer;
 
-        this.Chain.Fees.applyFeeRateBegin(tx, null, feeRate);
-        this.Chain.Fees.applyFeeRateEnd(tx, null, feeRate);
+        SolanaFees.applyFeeRateBegin(tx, null, feeRate);
+        SolanaFees.applyFeeRateEnd(tx, null, feeRate);
 
         const computedCommitedHeaders = this.computeCommitedHeaders(storedHeader, blockHeaderObj);
         const lastStoredHeader = computedCommitedHeaders[computedCommitedHeaders.length-1];
@@ -287,7 +293,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         const blockHashBuffer = Buffer.from(blockData.blockhash, 'hex').reverse();
         const topicKey = this.BtcRelayHeader(blockHashBuffer);
 
-        const data = await this.Events.findInEvents(topicKey, async (event) => {
+        const data = await this._Events.findInEvents(topicKey, async (event) => {
             if(event.name==="StoreFork" || event.name==="StoreHeader") {
                 const eventData: any = event.data;
                 const commitHash = Buffer.from(eventData.commitHash).toString("hex");
@@ -312,7 +318,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         const blockHashBuffer = Buffer.from(blockData.blockhash, "hex").reverse();
         const topicKey = this.BtcRelayHeader(blockHashBuffer);
 
-        const data = await this.Events.findInEvents(topicKey, async (event) => {
+        const data = await this._Events.findInEvents(topicKey, async (event) => {
             if(event.name==="StoreFork" || event.name==="StoreHeader") {
                 const eventData: any = event.data;
                 const commitHash = Buffer.from(eventData.commitHash).toString("hex");
@@ -336,15 +342,15 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         const mainState: any = await this.program.account.mainState.fetch(this.BtcRelayMainState);
         const storedCommitments = this.getBlockCommitmentsSet(mainState);
 
-        const data = await this.Events.findInEvents(this.program.programId, async (event) => {
+        const data = await this._Events.findInEvents(this.program.programId, async (event) => {
             if(event.name==="StoreFork" || event.name==="StoreHeader") {
                 const eventData: any = event.data;
                 const blockHashHex = Buffer.from(eventData.blockHash).reverse().toString("hex");
-                const isInMainChain = await this.bitcoinRpc.isInMainChain(blockHashHex).catch(() => false);
+                const isInMainChain = await this._bitcoinRpc.isInMainChain(blockHashHex).catch(() => false);
                 const commitHash = Buffer.from(eventData.commitHash).toString("hex");
                 //Check if this fork is part of main chain
                 if(isInMainChain && storedCommitments.has(commitHash)) {
-                    const blockHeader = await this.bitcoinRpc.getBlockHeader(blockHashHex);
+                    const blockHeader = await this._bitcoinRpc.getBlockHeader(blockHashHex);
                     if(blockHeader==null) return null;
                     return {
                         resultStoredHeader: new SolanaBtcStoredHeader(eventData.header),
@@ -513,7 +519,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         let forkId: number = mainState.forkCounter.toNumber();
 
         const txs: SolanaTx[] = [];
-        let action = new SolanaAction(signer.getPublicKey(), this.Chain);
+        let action = new SolanaAction(signer.getPublicKey(), this._Chain);
 
         let lastCheckedId = lastSweepId;
         for(
@@ -531,7 +537,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
 
             if(action.ixsLength()>=MAX_CLOSE_IX_PER_TX) {
                 await action.addToTxs(txs);
-                action = new SolanaAction(signer.getPublicKey(), this.Chain);
+                action = new SolanaAction(signer.getPublicKey(), this._Chain);
             }
         }
 
@@ -540,7 +546,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         }
 
         if(txs.length>0) {
-            const signatures = await this.Chain.sendAndConfirm(signer, txs, true);
+            const signatures = await this._Chain.sendAndConfirm(signer, txs, true);
             this.logger.info("sweepForkData(): forks swept, signatures: "+signatures.join());
         }
 
@@ -580,7 +586,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
      */
     public getMainFeeRate(signer: string | null): Promise<string> {
         const _signer = signer==null ? null : new PublicKey(signer);
-        return this.Chain.Fees.getFeeRate(_signer==null ? [this.BtcRelayMainState] : [
+        return this._Chain.Fees.getFeeRate(_signer==null ? [this.BtcRelayMainState] : [
             _signer,
             this.BtcRelayMainState
         ]);
@@ -591,7 +597,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
      */
     public getForkFeeRate(signer: string, forkId: number): Promise<string> {
         const _signer = new PublicKey(signer);
-        return this.Chain.Fees.getFeeRate([
+        return this._Chain.Fees.getFeeRate([
             _signer,
             this.BtcRelayMainState,
             this.BtcRelayFork(forkId, _signer)

--- a/src/solana/btcrelay/SolanaBtcRelay.ts
+++ b/src/solana/btcrelay/SolanaBtcRelay.ts
@@ -34,6 +34,8 @@ function serializeBlockHeader(e: BtcBlock): SolanaBtcHeader {
 };
 
 /**
+ * Solana BTC relay (bitcoin light client) program representation.
+ *
  * @category BTC Relay
  */
 export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> implements BtcRelay<SolanaBtcStoredHeader, {tx: Transaction, signers: Signer[]}, B, SolanaSigner> {
@@ -110,6 +112,12 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         );
     }
 
+    /**
+     * Creates an action that closes a fork account and refunds rent to the signer.
+     *
+     * @param signer Signer paying and receiving rent refund
+     * @param forkId Fork account identifier to close
+     */
     public async CloseForkAccount(signer: PublicKey, forkId: number): Promise<SolanaAction> {
         return new SolanaAction(signer, this.Chain,
             await this.program.methods
@@ -126,16 +134,37 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
         )
     }
 
+    /**
+     * PDA of the relay main state account.
+     */
     BtcRelayMainState = this.pda("state");
+    /**
+     * PDA helper for per-header topic accounts.
+     */
     BtcRelayHeader = this.pda("header", (hash: Buffer) => [hash]);
+    /**
+     * PDA helper for fork state accounts.
+     */
     BtcRelayFork = this.pda("fork",
         (forkId: number, pubkey: PublicKey) => [new BN(forkId).toArrayLike(Buffer, "le", 8), pubkey.toBuffer()]
     );
 
+    /**
+     * Bitcoin RPC client used for bitcoin chain lookups.
+     */
     bitcoinRpc: BitcoinRpc<B>;
 
+    /**
+     * @inheritDoc
+     */
     readonly maxHeadersPerTx: number = 5;
+    /**
+     * @inheritDoc
+     */
     readonly maxForkHeadersPerTx: number = 4;
+    /**
+     * @inheritDoc
+     */
     readonly maxShortForkHeadersPerTx: number = 4;
 
     constructor(
@@ -162,7 +191,7 @@ export class SolanaBtcRelay<B extends BtcBlock> extends SolanaProgramBase<any> i
     }
 
     /**
-     * Computes subsequent commited headers as they will appear on the blockchain when transactions
+     * Computes subsequent committed headers as they will appear on the blockchain when transactions
      *  are submitted & confirmed
      *
      * @param initialStoredHeader

--- a/src/solana/btcrelay/headers/SolanaBtcHeader.ts
+++ b/src/solana/btcrelay/headers/SolanaBtcHeader.ts
@@ -12,7 +12,7 @@ type SolanaBtcHeaderType = {
 }
 
 /**
- * Represents a bitcoin blockheader struct to be submitted to the Solana BTC relay program.
+ * Represents bitcoin blockheader data to be submitted to the Solana BTC relay program.
  *
  * @category BTC Relay
  */
@@ -48,9 +48,11 @@ export class SolanaBtcHeader implements BtcHeader {
     private readonly hash: Buffer;
 
     /**
-     * Constructs the bitcoin blockheader from Solana account/event data.
+     * Constructs the bitcoin blockheader
      *
-     * @param obj Decoded blockheader fields
+     * @param obj Blockheader fields
+     *
+     * @internal
      */
     constructor(obj: SolanaBtcHeaderType) {
         this.version = obj.version;

--- a/src/solana/btcrelay/headers/SolanaBtcHeader.ts
+++ b/src/solana/btcrelay/headers/SolanaBtcHeader.ts
@@ -21,31 +21,31 @@ export class SolanaBtcHeader implements BtcHeader {
     /**
      * Version field of the blockheader.
      */
-    version: number;
+    private readonly version: number;
     /**
      * Previous block hash in little-endian representation.
      */
-    reversedPrevBlockhash: number[];
+    private readonly reversedPrevBlockhash: number[];
     /**
      * Merkle root in little-endian representation.
      */
-    merkleRoot: number[];
+    private readonly merkleRoot: number[];
     /**
      * Block timestamp in UNIX seconds.
      */
-    timestamp: number;
+    private readonly timestamp: number;
     /**
      * Compact target (`nBits`) field.
      */
-    nbits: number;
+    private readonly nbits: number;
     /**
      * Nonce field.
      */
-    nonce: number;
+    private readonly nonce: number;
     /**
      * Reversed block hash bytes.
      */
-    hash: Buffer;
+    private readonly hash: Buffer;
 
     /**
      * Constructs the bitcoin blockheader from Solana account/event data.
@@ -102,6 +102,13 @@ export class SolanaBtcHeader implements BtcHeader {
      */
     getVersion(): number {
         return this.version;
+    }
+
+    /**
+     * Returns block hash bytes in little-endian representation.
+     */
+    getHash(): Buffer {
+        return this.hash;
     }
 
 }

--- a/src/solana/btcrelay/headers/SolanaBtcHeader.ts
+++ b/src/solana/btcrelay/headers/SolanaBtcHeader.ts
@@ -12,18 +12,46 @@ type SolanaBtcHeaderType = {
 }
 
 /**
+ * Represents a bitcoin blockheader struct to be submitted to the Solana BTC relay program.
+ *
  * @category BTC Relay
  */
 export class SolanaBtcHeader implements BtcHeader {
 
+    /**
+     * Version field of the blockheader.
+     */
     version: number;
+    /**
+     * Previous block hash in little-endian representation.
+     */
     reversedPrevBlockhash: number[];
+    /**
+     * Merkle root in little-endian representation.
+     */
     merkleRoot: number[];
+    /**
+     * Block timestamp in UNIX seconds.
+     */
     timestamp: number;
+    /**
+     * Compact target (`nBits`) field.
+     */
     nbits: number;
+    /**
+     * Nonce field.
+     */
     nonce: number;
+    /**
+     * Reversed block hash bytes.
+     */
     hash: Buffer;
 
+    /**
+     * Constructs the bitcoin blockheader from Solana account/event data.
+     *
+     * @param obj Decoded blockheader fields
+     */
     constructor(obj: SolanaBtcHeaderType) {
         this.version = obj.version;
         this.reversedPrevBlockhash = obj.reversedPrevBlockhash;
@@ -34,26 +62,44 @@ export class SolanaBtcHeader implements BtcHeader {
         this.hash = obj.hash;
     }
 
+    /**
+     * @inheritDoc
+     */
     getMerkleRoot(): Buffer {
         return Buffer.from(this.merkleRoot);
     }
 
+    /**
+     * @inheritDoc
+     */
     getNbits(): number {
         return this.nbits;
     }
 
+    /**
+     * @inheritDoc
+     */
     getNonce(): number {
         return this.nonce;
     }
 
+    /**
+     * @inheritDoc
+     */
     getReversedPrevBlockhash(): Buffer {
         return Buffer.from(this.reversedPrevBlockhash);
     }
 
+    /**
+     * @inheritDoc
+     */
     getTimestamp(): number {
         return this.timestamp;
     }
 
+    /**
+     * @inheritDoc
+     */
     getVersion(): number {
         return this.version;
     }

--- a/src/solana/btcrelay/headers/SolanaBtcStoredHeader.ts
+++ b/src/solana/btcrelay/headers/SolanaBtcStoredHeader.ts
@@ -11,16 +11,38 @@ export type SolanaBtcStoredHeaderType = {
 }
 
 /**
+ * Represents a bitcoin blockheader that has already been stored and committed in the Solana BTC relay program.
+ *
  * @category BTC Relay
  */
 export class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
 
+    /**
+     * Total accumulated chainwork for this header.
+     */
     chainWork: number[];
+    /**
+     * Stored bitcoin blockheader.
+     */
     header: SolanaBtcHeader;
+    /**
+     * Timestamp of the last difficulty adjustment.
+     */
     lastDiffAdjustment: number;
+    /**
+     * Blockheight of the stored header.
+     */
     blockheight: number;
+    /**
+     * Previous block timestamps tracked for median-time-past checks.
+     */
     prevBlockTimestamps: number[];
 
+    /**
+     * Constructs the stored bitcoin blockheader from Solana account/event data.
+     *
+     * @param obj Decoded stored-header fields
+     */
     constructor(obj: SolanaBtcStoredHeaderType) {
         this.chainWork = obj.chainWork;
         this.header = obj.header;
@@ -29,22 +51,37 @@ export class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
         this.prevBlockTimestamps = obj.prevBlockTimestamps;
     }
 
+    /**
+     * @inheritDoc
+     */
     getBlockheight(): number {
         return this.blockheight;
     }
 
+    /**
+     * @inheritDoc
+     */
     getChainWork(): Buffer {
         return Buffer.from(this.chainWork);
     }
 
+    /**
+     * @inheritDoc
+     */
     getHeader(): SolanaBtcHeader {
         return this.header;
     }
 
+    /**
+     * @inheritDoc
+     */
     getLastDiffAdjustment(): number {
         return this.lastDiffAdjustment;
     }
 
+    /**
+     * @inheritDoc
+     */
     getPrevBlockTimestamps(): number[] {
         return this.prevBlockTimestamps;
     }
@@ -93,6 +130,9 @@ export class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
         return lastDiffAdjustment;
     }
 
+    /**
+     * @inheritDoc
+     */
     computeNext(header: SolanaBtcHeader): SolanaBtcStoredHeader {
         return new SolanaBtcStoredHeader({
             chainWork: this.computeNextChainWork(header.nbits),

--- a/src/solana/btcrelay/headers/SolanaBtcStoredHeader.ts
+++ b/src/solana/btcrelay/headers/SolanaBtcStoredHeader.ts
@@ -39,9 +39,11 @@ export class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
     private readonly prevBlockTimestamps: number[];
 
     /**
-     * Constructs the stored bitcoin blockheader from Solana account/event data.
+     * Constructs the stored bitcoin blockheader from Solana event data.
      *
      * @param obj Decoded stored-header fields
+     *
+     * @internal
      */
     constructor(obj: SolanaBtcStoredHeaderType) {
         this.chainWork = obj.chainWork;

--- a/src/solana/btcrelay/headers/SolanaBtcStoredHeader.ts
+++ b/src/solana/btcrelay/headers/SolanaBtcStoredHeader.ts
@@ -20,23 +20,23 @@ export class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
     /**
      * Total accumulated chainwork for this header.
      */
-    chainWork: number[];
+    private readonly chainWork: number[];
     /**
      * Stored bitcoin blockheader.
      */
-    header: SolanaBtcHeader;
+    private readonly header: SolanaBtcHeader;
     /**
      * Timestamp of the last difficulty adjustment.
      */
-    lastDiffAdjustment: number;
+    private readonly lastDiffAdjustment: number;
     /**
      * Blockheight of the stored header.
      */
-    blockheight: number;
+    private readonly blockheight: number;
     /**
      * Previous block timestamps tracked for median-time-past checks.
      */
-    prevBlockTimestamps: number[];
+    private readonly prevBlockTimestamps: number[];
 
     /**
      * Constructs the stored bitcoin blockheader from Solana account/event data.
@@ -97,7 +97,7 @@ export class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
         for(let i=1;i<10;i++) {
             prevBlockTimestamps[i-1] = prevBlockTimestamps[i];
         }
-        prevBlockTimestamps[9] = this.header.timestamp;
+        prevBlockTimestamps[9] = this.header.getTimestamp();
         return prevBlockTimestamps;
     }
 
@@ -135,10 +135,10 @@ export class SolanaBtcStoredHeader implements BtcStoredHeader<SolanaBtcHeader> {
      */
     computeNext(header: SolanaBtcHeader): SolanaBtcStoredHeader {
         return new SolanaBtcStoredHeader({
-            chainWork: this.computeNextChainWork(header.nbits),
+            chainWork: this.computeNextChainWork(header.getNbits()),
             prevBlockTimestamps: this.computeNextBlockTimestamps(),
             blockheight: this.blockheight+1,
-            lastDiffAdjustment: this.computeNextLastDiffAdjustment(header.timestamp),
+            lastDiffAdjustment: this.computeNextLastDiffAdjustment(header.getTimestamp()),
             header
         });
     }

--- a/src/solana/chain/SolanaAction.ts
+++ b/src/solana/chain/SolanaAction.ts
@@ -90,7 +90,7 @@ export class SolanaAction {
 
         if(block!=null) {
             tx.recentBlockhash = block.blockhash;
-            tx.lastValidBlockHeight = block.blockHeight + this.root.TX_SLOT_VALIDITY;
+            tx.lastValidBlockHeight = block.blockHeight + this.root._TX_SLOT_VALIDITY;
         }
 
         return {

--- a/src/solana/chain/SolanaAction.ts
+++ b/src/solana/chain/SolanaAction.ts
@@ -1,6 +1,7 @@
 import {PublicKey, Signer, Transaction, TransactionInstruction} from "@solana/web3.js";
 import {SolanaTx} from "./modules/SolanaTransactions";
 import {SolanaChainInterface} from "./SolanaChainInterface";
+import {SolanaFees} from "./modules/SolanaFees";
 
 
 export class SolanaAction {
@@ -83,9 +84,9 @@ export class SolanaAction {
             tx.add(this.instructions[0]);
             instructions = this.instructions.slice(1);
         }
-        this.root.Fees.applyFeeRateBegin(tx, this.computeBudget, feeRate);
+        SolanaFees.applyFeeRateBegin(tx, this.computeBudget, feeRate);
         instructions.forEach(ix => tx.add(ix));
-        this.root.Fees.applyFeeRateEnd(tx, this.computeBudget, feeRate);
+        SolanaFees.applyFeeRateEnd(tx, this.computeBudget, feeRate);
 
         if(block!=null) {
             tx.recentBlockhash = block.blockhash;

--- a/src/solana/chain/SolanaChainInterface.ts
+++ b/src/solana/chain/SolanaChainInterface.ts
@@ -36,20 +36,56 @@ export class SolanaChainInterface implements ChainInterface<
     "SOLANA",
     Wallet
 > {
+    /**
+     * @inheritDoc
+     */
     readonly chainId = "SOLANA";
 
+    /**
+     * Average Solana slot time in milliseconds.
+     */
     public readonly SLOT_TIME = 400;
+    /**
+     * Approximate number of recent slots for which a transaction remains valid.
+     */
     public readonly TX_SLOT_VALIDITY = 151;
 
+    /**
+     * Underlying Solana web3.js connection.
+     */
     readonly connection: Connection;
+    /**
+     * Retry policy used by chain modules.
+     */
     readonly retryPolicy?: SolanaRetryPolicy;
 
+    /**
+     * Block-related read module.
+     */
     public readonly Blocks: SolanaBlocks;
+    /**
+     * Fee estimation and fee-rate module.
+     */
     public Fees: SolanaFees;
+    /**
+     * Slot-related read module.
+     */
     public readonly Slots: SolanaSlots;
+    /**
+     * Token operations module.
+     */
     public readonly Tokens: SolanaTokens;
+    /**
+     * Transaction send/confirm/serialization module.
+     */
     public readonly Transactions: SolanaTransactions;
+    /**
+     * Signature utilities module.
+     */
     public readonly Signatures: SolanaSignatures;
+    /**
+     * Event/log scanning module.
+     */
     public readonly Events: SolanaEvents;
 
     protected readonly logger = getLogger(this.constructor.name+": ");
@@ -243,10 +279,20 @@ export class SolanaChainInterface implements ChainInterface<
         return this.Transactions.offBeforeTxSigned(callback);
     }
 
+    /**
+     * Registers a low-level transaction sender override hook.
+     *
+     * @param callback Callback used for raw transaction publishing
+     */
     onSendTransaction(callback: (tx: Buffer, options?: SendOptions) => Promise<string>): void {
         this.Transactions.onSendTransaction(callback);
     }
 
+    /**
+     * Unregisters a previously registered transaction sender override hook.
+     *
+     * @param callback Previously registered callback
+     */
     offSendTransaction(callback: (tx: Buffer, options?: SendOptions) => Promise<string>): boolean {
         return this.Transactions.offSendTransaction(callback);
     }

--- a/src/solana/chain/SolanaChainInterface.ts
+++ b/src/solana/chain/SolanaChainInterface.ts
@@ -55,21 +55,25 @@ export class SolanaChainInterface implements ChainInterface<
 
     /**
      * Average Solana slot time in milliseconds.
+     * @internal
      */
-    public readonly SLOT_TIME = 400;
+    readonly _SLOT_TIME = 400;
     /**
      * Approximate number of recent slots for which a transaction remains valid.
+     * @internal
      */
-    public readonly TX_SLOT_VALIDITY = 151;
+    readonly _TX_SLOT_VALIDITY = 151;
 
     /**
      * Underlying Solana web3.js connection.
+     * @internal
      */
-    readonly connection: Connection;
+    readonly _connection: Connection;
     /**
      * Retry policy used by chain modules.
+     * @internal
      */
-    readonly retryPolicy?: SolanaRetryPolicy;
+    readonly _retryPolicy?: SolanaRetryPolicy;
 
     /**
      * Block-related read module.
@@ -100,6 +104,9 @@ export class SolanaChainInterface implements ChainInterface<
      */
     public readonly Events: SolanaEvents;
 
+    /**
+     * @internal
+     */
     protected readonly logger = getLogger(this.constructor.name+": ");
 
     constructor(
@@ -107,8 +114,8 @@ export class SolanaChainInterface implements ChainInterface<
         retryPolicy?: SolanaRetryPolicy,
         solanaFeeEstimator: SolanaFees = new SolanaFees(connection)
     ) {
-        this.connection = connection;
-        this.retryPolicy = retryPolicy;
+        this._connection = connection;
+        this._retryPolicy = retryPolicy;
 
         this.Blocks = new SolanaBlocks(this);
         this.Fees = solanaFeeEstimator;

--- a/src/solana/chain/SolanaChainInterface.ts
+++ b/src/solana/chain/SolanaChainInterface.ts
@@ -19,9 +19,21 @@ import {Wallet} from "@coral-xyz/anchor/dist/cjs/provider";
  * @category Chain Interface
  */
 export type SolanaRetryPolicy = {
+    /**
+     * Maximum retries to be attempted
+     */
     maxRetries?: number,
+    /**
+     * Default delay between retries
+     */
     delay?: number,
+    /**
+     * Whether the delays should scale exponentially, i.e. 1 second, 2 seconds, 4 seconds, 8 seconds
+     */
     exponential?: boolean,
+    /**
+     * Interval between re-sending Solana transaction to the RPC
+     */
     transactionResendInterval?: number
 }
 

--- a/src/solana/chain/SolanaModule.ts
+++ b/src/solana/chain/SolanaModule.ts
@@ -13,8 +13,8 @@ export class SolanaModule {
     constructor(
         root: SolanaChainInterface
     ) {
-        this.connection = root.connection;
-        this.retryPolicy = root.retryPolicy;
+        this.connection = root._connection;
+        this.retryPolicy = root._retryPolicy;
         this.root = root;
     }
 

--- a/src/solana/chain/modules/SolanaFees.ts
+++ b/src/solana/chain/modules/SolanaFees.ts
@@ -13,18 +13,30 @@ import {getLogger, SolanaTxUtils} from "../../../utils/Utils";
 const MAX_FEE_AGE = 5000;
 
 /**
- * Bribe endpoint configuration used for Jito-compatible fee payment flows.
+ * Bribe configuration used for Jito-like tips that handled outside of native Solana network fees
  *
  * @category Chain Interface
  */
 export type FeeBribeData = {
+    /**
+     * Address to send the bribe to (e.g. Jito tip)
+     */
     address: string,
+    /**
+     * HTTP endpoint to send the transaction to instead of the RPC, e.g. a Jito endpoint
+     */
     endpoint: string,
+    /**
+     * An optional function for overriding the bribe to be sent to the specified address for the tx
+     */
     getBribeFee?: (original: bigint) => bigint
 };
 
 /**
- * Fee estimation service for Solana chains.
+ * Fee estimation service for the Solana network. Uses client-side fee estimation algorithm by default, which
+ *  fetches a bunch (default 8) random blocks in the past period (default 150) and computes the average fee. It
+ *  automatically detects whether the underlying RPC endpoint is a Helius one which features the `getPriorityFeeEstimate`
+ *  endpoint, and if available uses that one.
  *
  * @category Chain Interface
  */
@@ -47,6 +59,21 @@ export class SolanaFees {
         feeRate: Promise<bigint>
     };
 
+    /**
+     * @param connection Underlying Solana network connection to use for read access to Solana
+     * @param maxFeeMicroLamports Maximum allowed fee in microLamports/CU (1/1,000,000 of a lamport per compute unit)
+     * @param numSamples Number of samples to use when estimating the global fee on the client-side, this many blocks are
+     *  sampled from the last `period` blocks to estimate an average fee rate
+     * @param period Period of past blocks to sample random blocks from when estimating the global fee on the client-side
+     * @param useHeliusApi Whether to use the helius API or not, default to `"auto"`, which automatically detects if the
+     *  underlying RPC supports Helius's `getPriorityFeeEstimate` RPC call
+     * @param heliusFeeLevel Fee level to use when fetching the fee rate from Helius's `getPriorityFeeEstimate` RPC endpoint,
+     *  for the meaning of the different levels refer to https://www.helius.dev/docs/priority-fee-api#priority-levels-explained
+     * @param getStaticFee Optional function for adding a base fee to transactions (this function returns the base fee
+     *  in lamports to be added to the transaction) - this fee doesn't scale with CUs of the transaction and is instead
+     *  applied as-is
+     * @param bribeData Bribe fee configuration (used for e.g. Jito tips)
+     */
     constructor(
         connection: Connection,
         maxFeeMicroLamports: number = 250000,
@@ -376,14 +403,29 @@ export class SolanaFees {
     }
 
     /**
-     * Applies fee rate to a transaction at the beginning of the transaction (has to be called after
-     *  feePayer is set for the tx), specifically adds the setComputeUnitLimit & setComputeUnitPrice instruction
+     * Applies fee rate to a transaction, should be called before adding instructions to the transaction, specifically
+     *  it adds the setComputeUnitLimit & setComputeUnitPrice instruction.
+     *
+     * @example
+     * ```typescript
+     * const feeRate = solanaFees.getFeeRate([...writeableAccounts]);
+     * const tx = new Transaction();
+     * //Apply the fee rate part at the beginning of the transaction (specifically setComputeUnitLimit & setComputeUnitPrice)
+     * SolanaFees.applyFeeRateBegin(tx, feeRate);
+     * //Add instructions here
+     * tx.add(instruction1);
+     * tx.add(instruction2);
+     * //Set the fee payer
+     * tx.feePayer = feePayerPublicKey;
+     * //Apply the fee rate part at the end of the transaction (specifically the transfer to the bribe account, e.g. Jito tip)
+     * SolanaFees.applyFeeRateEnd(tx, feeRate);
+     * ```
      *
      * @param tx
      * @param computeBudget
      * @param feeRate
      */
-    public applyFeeRateBegin(tx: Transaction, computeBudget: number | null, feeRate: string) {
+    public static applyFeeRateBegin(tx: Transaction, computeBudget: number | null, feeRate: string) {
         if(feeRate==null) return;
 
         const hashArr = feeRate.split("#");
@@ -414,14 +456,29 @@ export class SolanaFees {
     }
 
     /**
-     * Applies fee rate to the end of the transaction (has to be called after feePayer is set for the tx),
-     *  specifically adds the bribe SystemProgram.transfer instruction
+     * Applies fee rate to a transaction, should be called after adding instructions to the transaction, specifically
+     *  it adds the adds the bribe SystemProgram.transfer instruction.
+     *
+     * @example
+     * ```typescript
+     * const feeRate = solanaFees.getFeeRate([...writeableAccounts]);
+     * const tx = new Transaction();
+     * //Apply the fee rate part at the beginning of the transaction (specifically setComputeUnitLimit & setComputeUnitPrice)
+     * SolanaFees.applyFeeRateBegin(tx, feeRate);
+     * //Add instructions here
+     * tx.add(instruction1);
+     * tx.add(instruction2);
+     * //Set the fee payer
+     * tx.feePayer = feePayerPublicKey;
+     * //Apply the fee rate part at the end of the transaction (specifically the transfer to the bribe account, e.g. Jito tip)
+     * SolanaFees.applyFeeRateEnd(tx, feeRate);
+     * ```
      *
      * @param tx
      * @param computeBudget
      * @param feeRate
      */
-    public applyFeeRateEnd(tx: Transaction, computeBudget: number | null, feeRate: string) {
+    public static applyFeeRateEnd(tx: Transaction, computeBudget: number | null, feeRate: string) {
         if(feeRate==null) return;
 
         const hashArr = feeRate.split("#");
@@ -449,8 +506,8 @@ export class SolanaFees {
     /**
      * Checks if the transaction should be submitted over Jito and if yes submits it
      *
-     * @param tx
-     * @param options
+     * @param tx Raw signed transaction to be attempted to be sent over Jito
+     * @param options Send options for the sendTransaction RPC call
      * @returns {Promise<string | null>} null if the transaction was not sent over Jito, tx signature when tx was sent over Jito
      */
     submitTx(tx: Buffer, options?: SendOptions): Promise<string | null> {

--- a/src/solana/chain/modules/SolanaFees.ts
+++ b/src/solana/chain/modules/SolanaFees.ts
@@ -12,12 +12,22 @@ import {getLogger, SolanaTxUtils} from "../../../utils/Utils";
 
 const MAX_FEE_AGE = 5000;
 
+/**
+ * Bribe endpoint configuration used for Jito-compatible fee payment flows.
+ *
+ * @category Chain Interface
+ */
 export type FeeBribeData = {
     address: string,
     endpoint: string,
     getBribeFee?: (original: bigint) => bigint
 };
 
+/**
+ * Fee estimation service for Solana chains.
+ *
+ * @category Chain Interface
+ */
 export class SolanaFees {
 
     private readonly connection: Connection;

--- a/src/solana/chain/modules/SolanaSlots.ts
+++ b/src/solana/chain/modules/SolanaSlots.ts
@@ -5,7 +5,7 @@ import {Commitment} from "@solana/web3.js";
 export class SolanaSlots extends SolanaModule {
 
     public readonly SLOT_CACHE_SLOTS = 12;
-    public readonly SLOT_CACHE_TIME = this.SLOT_CACHE_SLOTS*this.root.SLOT_TIME;
+    public readonly SLOT_CACHE_TIME = this.SLOT_CACHE_SLOTS*this.root._SLOT_TIME;
 
     private slotCache: {
         [key in Commitment]?: {
@@ -71,7 +71,7 @@ export class SolanaSlots extends SolanaModule {
         let cachedSlotData = this.slotCache[commitment];
 
         if(cachedSlotData!=null && Date.now()-cachedSlotData.timestamp<this.SLOT_CACHE_TIME) {
-            return (await cachedSlotData.slot) + Math.floor((Date.now()-cachedSlotData.timestamp)/this.root.SLOT_TIME);
+            return (await cachedSlotData.slot) + Math.floor((Date.now()-cachedSlotData.timestamp)/this.root._SLOT_TIME);
         }
 
         cachedSlotData = this.fetchAndSaveSlot(commitment);

--- a/src/solana/chain/modules/SolanaTransactions.ts
+++ b/src/solana/chain/modules/SolanaTransactions.ts
@@ -12,7 +12,18 @@ import {Buffer} from "buffer";
 import {SolanaSigner} from "../../wallet/SolanaSigner";
 import {TransactionRevertedError} from "@atomiqlabs/base";
 
+/**
+ * Solana unsigned transaction type, optionally also contains additional signers which should be used to additionally
+ *  sign the transaction.
+ *
+ * @category Chain Interface
+ */
 export type SolanaTx = {tx: Transaction, signers: Signer[]};
+/**
+ * Alias for signed Solana transaction, uses the native transaction type of `@solana/web3.js`
+ *
+ * @category Chain Interface
+ */
 export type SignedSolanaTx = Transaction;
 
 export class SolanaTransactions extends SolanaModule {

--- a/src/solana/connection/ConnectionWithRetries.ts
+++ b/src/solana/connection/ConnectionWithRetries.ts
@@ -1,0 +1,79 @@
+import {Commitment, Connection, ConnectionConfig} from "@solana/web3.js";
+import {tryWithRetries} from "../../utils/Utils";
+
+export type ConnectionWithRetriesConfig = ConnectionConfig & {
+    retryPolicy?: {
+        maxRetries?: number, delay?: number, exponential?: boolean
+    };
+    requestTimeout?: number;
+};
+
+export class ConnectionWithRetries extends Connection {
+
+    readonly retryPolicy?: {
+        maxRetries?: number, delay?: number, exponential?: boolean
+    };
+    readonly requestTimeout: number;
+
+    constructor(endpoint: string, commitmentOrConfig?: Commitment | ConnectionWithRetriesConfig) {
+        let config: ConnectionWithRetriesConfig;
+        if(typeof(commitmentOrConfig)==="string") {
+            config = {commitment: commitmentOrConfig};
+        } else {
+            config = commitmentOrConfig ?? {};
+        }
+
+        config.fetch = (input: RequestInfo | URL, init?: RequestInit) => tryWithRetries(
+            async () => {
+                let timedOut = false;
+                const abortController = new AbortController();
+                const timeoutHandle = setTimeout(() => {
+                    timedOut = true;
+                    abortController.abort('Timed out');
+                }, this.requestTimeout);
+                let originalSignal: AbortSignal | undefined;
+                if (init?.signal != null) {
+                    originalSignal = init.signal;
+                    init.signal.addEventListener('abort', (reason) => {
+                        clearTimeout(timeoutHandle);
+                        abortController.abort(reason);
+                    });
+                }
+                const result = await fetch(input, {
+                    ...init,
+                    signal: abortController.signal
+                }).catch((e: any) => {
+                    console.error('SolanaWalletProvider: fetchWithTimeout(' + typeof e + '): ', e);
+                    if (
+                        e.name === 'AbortError' &&
+                        (originalSignal == null || !originalSignal.aborted) &&
+                        timedOut
+                    ) {
+                        throw new Error('Network request timed out');
+                    } else {
+                        throw e;
+                    }
+                });
+                if(Math.floor(result.status/100)===5) {
+                    throw new Error(`Internal server error: ${result.status}`);
+                }
+                if(result.status===429) {
+                    throw new Error(`Too many requests (429)`);
+                }
+                return result;
+            },
+            this.retryPolicy,
+            (e) =>
+                !e?.message?.startsWith?.("Internal server error: ") &&
+                e?.message!=="Network request timed out" &&
+                e?.message!=="Too many requests (429)",
+            init?.signal ?? undefined
+        );
+        config.disableRetryOnRateLimit = true;
+
+        super(endpoint, commitmentOrConfig);
+        this.retryPolicy = config?.retryPolicy;
+        this.requestTimeout = config?.requestTimeout ?? 15*1000;
+    }
+
+}

--- a/src/solana/connection/ConnectionWithRetries.ts
+++ b/src/solana/connection/ConnectionWithRetries.ts
@@ -8,13 +8,30 @@ export type ConnectionWithRetriesConfig = ConnectionConfig & {
     requestTimeout?: number;
 };
 
+/**
+ * Solana connection with retry logic and request timeout handling for RPC calls.
+ *
+ * @category Providers
+ */
 export class ConnectionWithRetries extends Connection {
 
+    /**
+     * Retry policy used for RPC requests.
+     */
     readonly retryPolicy?: {
         maxRetries?: number, delay?: number, exponential?: boolean
     };
+    /**
+     * Per-request timeout in milliseconds.
+     */
     readonly requestTimeout: number;
 
+    /**
+     * Constructs a retry-enabled Solana connection.
+     *
+     * @param endpoint RPC endpoint URL
+     * @param commitmentOrConfig Commitment level or full connection configuration
+     */
     constructor(endpoint: string, commitmentOrConfig?: Commitment | ConnectionWithRetriesConfig) {
         let config: ConnectionWithRetriesConfig;
         if(typeof(commitmentOrConfig)==="string") {

--- a/src/solana/events/SolanaChainEvents.ts
+++ b/src/solana/events/SolanaChainEvents.ts
@@ -78,7 +78,7 @@ export class SolanaChainEvents extends SolanaChainEventsBrowser {
         }
     }
 
-    async setupHttpPolling() {
+    private async setupHttpPolling() {
         this.stopped = false;
         let func: () => Promise<void>;
         func = async () => {
@@ -91,6 +91,9 @@ export class SolanaChainEvents extends SolanaChainEventsBrowser {
         await func();
     }
 
+    /**
+     * @inheritDoc
+     */
     async init(noAutomaticPoll?: boolean): Promise<void> {
         if(noAutomaticPoll) return;
         try {
@@ -101,6 +104,9 @@ export class SolanaChainEvents extends SolanaChainEventsBrowser {
         this.setupWebsocket();
     }
 
+    /**
+     * @inheritDoc
+     */
     stop(): Promise<void> {
         this.stopped = true;
         if(this.timeout!=null) clearTimeout(this.timeout)

--- a/src/solana/events/SolanaChainEventsBrowser.ts
+++ b/src/solana/events/SolanaChainEventsBrowser.ts
@@ -15,6 +15,11 @@ import {
 import {SwapProgram} from "../swaps/programTypes";
 import {Buffer} from "buffer";
 
+/**
+ * Parsed event payload grouped by originating transaction metadata.
+ *
+ * @category Events
+ */
 export type EventObject = {
     events: ProgramEvent<SwapProgram>[],
     instructions?: (InstructionWithAccounts<SwapProgram> | null)[],
@@ -25,6 +30,11 @@ export type EventObject = {
 const LOG_FETCH_LIMIT = 500;
 const PROCESSED_SIGNATURES_BACKLOG = 100;
 
+/**
+ * Current state of Solana event listener progress.
+ *
+ * @category Events
+ */
 export type SolanaEventListenerState = {
     signature: string,
     slot: number
@@ -34,6 +44,8 @@ export type SolanaEventListenerState = {
  * Solana on-chain event handler for front-end systems without access to fs, uses pure WS to subscribe, might lose
  *  out on some events if the network is unreliable, front-end systems should take this into consideration and not
  *  rely purely on events
+ *
+ * @category Events
  */
 export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, SolanaEventListenerState> {
 

--- a/src/solana/events/SolanaChainEventsBrowser.ts
+++ b/src/solana/events/SolanaChainEventsBrowser.ts
@@ -31,12 +31,18 @@ const LOG_FETCH_LIMIT = 500;
 const PROCESSED_SIGNATURES_BACKLOG = 100;
 
 /**
- * Current state of Solana event listener progress.
+ * Current cursor of Solana event listener state.
  *
  * @category Events
  */
 export type SolanaEventListenerState = {
+    /**
+     * Last processed transaction's signature
+     */
     signature: string,
+    /**
+     * Last processed transaction's slot
+     */
     slot: number
 };
 
@@ -49,10 +55,25 @@ export type SolanaEventListenerState = {
  */
 export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, SolanaEventListenerState> {
 
+    /**
+     * @internal
+     */
     protected readonly listeners: EventListener<SolanaSwapData>[] = [];
+    /**
+     * @internal
+     */
     protected readonly connection: Connection;
+    /**
+     * @internal
+     */
     protected readonly solanaSwapProgram: SolanaSwapProgram;
+    /**
+     * @internal
+     */
     protected eventListeners: number[] = [];
+    /**
+     * @internal
+     */
     protected readonly logger = getLogger("SolanaChainEventsBrowser: ");
 
     private readonly logFetchLimit: number;
@@ -94,8 +115,8 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
         if(transaction.meta==null) throw new Error(`Transaction 'meta' not found for Solana tx: ${signature}`);
         if(transaction.meta.err!=null || transaction.meta.logMessages==null) return null;
 
-        const instructions = this.solanaSwapProgram.Events.decodeInstructions(transaction.transaction.message);
-        const events = this.solanaSwapProgram.Events.parseLogs(transaction.meta.logMessages);
+        const instructions = this.solanaSwapProgram._Events.decodeInstructions(transaction.transaction.message);
+        const events = this.solanaSwapProgram._Events.parseLogs(transaction.meta.logMessages);
 
         return {
             instructions,
@@ -148,7 +169,7 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
         });
         if(transaction.meta==null) throw new Error("Transaction 'meta' not found!");
         if(transaction.meta.err!=null) return null;
-        return this.solanaSwapProgram.Events.decodeInstructions(transaction.transaction.message);
+        return this.solanaSwapProgram._Events.decodeInstructions(transaction.transaction.message);
     }
 
     /**
@@ -176,6 +197,9 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
         }
     }
 
+    /**
+     * @internal
+     */
     protected parseInitializeEvent(data: IdlEvents<SwapProgram>["InitializeEvent"], eventObject: EventObject): InitializeEvent<SolanaSwapData> {
         const paymentHash: string = Buffer.from(data.hash).toString("hex");
         const txoHash: string = Buffer.from(data.txoHash).toString("hex");
@@ -189,6 +213,9 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
         );
     }
 
+    /**
+     * @internal
+     */
     protected parseRefundEvent(data: IdlEvents<SwapProgram>["RefundEvent"]): RefundEvent<SolanaSwapData> {
         const paymentHash: string = Buffer.from(data.hash).toString("hex");
         const escrowHash = toEscrowHash(paymentHash, data.sequence);
@@ -197,6 +224,9 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
         return new RefundEvent<SolanaSwapData>(escrowHash);
     }
 
+    /**
+     * @internal
+     */
     protected parseClaimEvent(data: IdlEvents<SwapProgram>["ClaimEvent"]): ClaimEvent<SolanaSwapData> {
         const secret: string = Buffer.from(data.secret).toString("hex");
         const paymentHash: string = Buffer.from(data.hash).toString("hex");
@@ -210,11 +240,11 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
      * Processes event as received from the chain, parses it & calls event listeners
      *
      * @param eventObject
-     * @protected
+     * @internal
      */
     protected async processEvent(eventObject : EventObject) {
         let parsedEvents: SwapEvent<SolanaSwapData>[] = eventObject.events.map(event => {
-            let parsedEvent: SwapEvent<SolanaSwapData>;
+            let parsedEvent: SwapEvent<SolanaSwapData> | undefined;
             switch(event.name) {
                 case "ClaimEvent":
                     parsedEvent = this.parseClaimEvent(event.data);
@@ -226,6 +256,7 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
                     parsedEvent = this.parseInitializeEvent(event.data, eventObject);
                     break;
             }
+            if(parsedEvent==null) return null;
             (parsedEvent as any).meta = {
                 blockTime: eventObject.blockTime,
                 timestamp: eventObject.blockTime,
@@ -243,7 +274,7 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
      * Returns websocket event handler for specific event type
      *
      * @param name
-     * @protected
+     * @internal
      * @returns event handler to be passed to program's addEventListener function
      */
     protected getWsEventHandler<E extends "InitializeEvent" | "RefundEvent" | "ClaimEvent">(
@@ -269,7 +300,7 @@ export class SolanaChainEventsBrowser implements ChainEvents<SolanaSwapData, Sol
     /**
      * Sets up event handlers listening for swap events over websocket
      *
-     * @protected
+     * @internal
      */
     protected setupWebsocket() {
         const program = this.solanaSwapProgram.program;

--- a/src/solana/program/SolanaProgramBase.ts
+++ b/src/solana/program/SolanaProgramBase.ts
@@ -13,19 +13,28 @@ import {getLogger} from "../../utils/Utils";
  */
 export class SolanaProgramBase<T extends Idl> {
 
+    /**
+     * @internal
+     */
     protected readonly logger = getLogger(this.constructor.name+": ");
 
     program: Program<T>;
 
-    public readonly Events: SolanaProgramEvents<T>;
-    public readonly Chain: SolanaChainInterface;
+    /**
+     * @internal
+     */
+    readonly _Events: SolanaProgramEvents<T>;
+    /**
+     * @internal
+     */
+    readonly _Chain: SolanaChainInterface;
 
     constructor(
         chainInterface: SolanaChainInterface,
         programIdl: any,
         programAddress?: string
     ) {
-        this.Chain = chainInterface;
+        this._Chain = chainInterface;
 
         this.program = new Program<T>(
             programIdl as any,
@@ -33,23 +42,27 @@ export class SolanaProgramBase<T extends Idl> {
             new AnchorProvider(chainInterface.connection, new SolanaKeypairWallet(Keypair.generate()), {})
         );
 
-        this.Events = new SolanaProgramEvents(chainInterface, this);
+        this._Events = new SolanaProgramEvents(chainInterface, this);
     }
 
     /**
      * Derives static PDA address from the seed
      *
      * @param seed
+     *
+     * @internal
      */
-    public pda(seed: string): PublicKey;
+    protected pda(seed: string): PublicKey;
     /**
      * Returns a function for deriving a dynamic PDA address from seed + dynamic arguments
      *
      * @param seed
      * @param func function translating the function argument to Buffer[]
+     *
+     * @internal
      */
-    public pda<T extends Array<any>>(seed: string, func: (...args: T) => Buffer[]): (...args: T) => PublicKey;
-    public pda<T extends Array<any>>(seed: string, func?: (...args: T) => Buffer[]): PublicKey | ((...args: T) => PublicKey) {
+    protected pda<T extends Array<any>>(seed: string, func: (...args: T) => Buffer[]): (...args: T) => PublicKey;
+    protected pda<T extends Array<any>>(seed: string, func?: (...args: T) => Buffer[]): PublicKey | ((...args: T) => PublicKey) {
         if(func==null) {
             return PublicKey.findProgramAddressSync(
                 [Buffer.from(seed)],
@@ -68,8 +81,10 @@ export class SolanaProgramBase<T extends Idl> {
      * Returns a function for deriving a dynamic deterministic keypair from dynamic arguments
      *
      * @param func function translating the function argument to Buffer[] to be used for deriving the keypair
+     *
+     * @internal
      */
-    public keypair<T extends Array<any>>(func: (...args: T) => Buffer[]): (...args: T) => Keypair {
+    _keypair<T extends Array<any>>(func: (...args: T) => Buffer[]): (...args: T) => Keypair {
         return (...args: T) => {
             const res = func(...args);
             const buff = sha256(Buffer.concat(res));

--- a/src/solana/program/SolanaProgramBase.ts
+++ b/src/solana/program/SolanaProgramBase.ts
@@ -39,7 +39,7 @@ export class SolanaProgramBase<T extends Idl> {
         this.program = new Program<T>(
             programIdl as any,
             programAddress || programIdl.metadata.address,
-            new AnchorProvider(chainInterface.connection, new SolanaKeypairWallet(Keypair.generate()), {})
+            new AnchorProvider(chainInterface._connection, new SolanaKeypairWallet(Keypair.generate()), {})
         );
 
         this._Events = new SolanaProgramEvents(chainInterface, this);

--- a/src/solana/swaps/SolanaSwapData.ts
+++ b/src/solana/swaps/SolanaSwapData.ts
@@ -42,31 +42,94 @@ export function isSerializedData(obj: any): obj is ({type: "sol"} & Serialized<S
 }
 
 /**
+ * Represents Solana swap data for executing PrTLC (on-chain) or HTLC (lightning) based swaps.
+ *
  * @category Swaps
  */
 export class SolanaSwapData extends SwapData {
 
+    /**
+     * Offerer address funding the swap.
+     */
     offerer: PublicKey;
+    /**
+     * Claimer address receiving the swap funds.
+     */
     claimer: PublicKey;
+    /**
+     * Token mint used for the swap.
+     */
     token: PublicKey;
+    /**
+     * Swap amount.
+     */
     amount: BN;
+    /**
+     * Payment hash identifying the swap.
+     */
     paymentHash: string;
+    /**
+     * Swap sequence used for uniqueness.
+     */
     sequence: BN;
+    /**
+     * Swap expiry timestamp.
+     */
     expiry: BN;
+    /**
+     * Nonce used in claim hash derivation.
+     */
     nonce: BN;
+    /**
+     * Required bitcoin confirmations for claim.
+     */
     confirmations: number;
+    /**
+     * Whether funds are paid out to claimer wallet directly.
+     */
     payOut: boolean;
+    /**
+     * Solana on-chain swap kind discriminator.
+     */
     kind: number;
+    /**
+     * Whether funds are paid in from offerer wallet.
+     */
     payIn: boolean;
+    /**
+     * Optional claimer associated token account.
+     */
     claimerAta?: PublicKey;
+    /**
+     * Optional offerer associated token account.
+     */
     offererAta?: PublicKey;
 
+    /**
+     * Security deposit amount.
+     */
     securityDeposit: BN;
+    /**
+     * Claimer bounty amount.
+     */
     claimerBounty: BN;
 
+    /**
+     * Optional txo hash hint.
+     */
     txoHash?: string;
 
+    /**
+     * Creates swap data from structured constructor arguments.
+     *
+     * @param args Swap data fields
+     */
     constructor(args: SolanaSwapDataCtorArgs);
+    /**
+     * Deserializes swap data from serialized storage representation.
+     *
+     * @param data Serialized swap data from {@link SolanaSwapData.serialize}
+     */
     constructor(data: {type: "sol"} & Serialized<SolanaSwapData>);
 
     constructor(data: ({type: "sol"} & Serialized<SolanaSwapData>) | SolanaSwapDataCtorArgs) {
@@ -312,6 +375,9 @@ export class SolanaSwapData extends SwapData {
         return toBigInt(this.claimerBounty.lt(this.securityDeposit) ? this.securityDeposit : this.claimerBounty);
     }
 
+    /**
+     * Serializes the swap data into the Solana program `SwapData` struct representation.
+     */
     toSwapDataStruct(): IdlTypes<SwapProgram>["SwapData"] {
         return {
             kind: SwapTypeEnum.fromNumber(this.kind as 0 | 1 | 2 | 3),
@@ -326,6 +392,11 @@ export class SolanaSwapData extends SwapData {
         }
     }
 
+    /**
+     * Checks whether the provided escrow account matches this swap data.
+     *
+     * @param account Escrow account data fetched from chain
+     */
     correctPDA(account: IdlAccounts<SwapProgram>["escrowState"]): boolean {
         return SwapTypeEnum.toNumber(account.data.kind)===this.kind &&
             account.data.confirmations===this.confirmations &&
@@ -379,12 +450,11 @@ export class SolanaSwapData extends SwapData {
     }
 
     /**
-     * Converts initialize instruction data into {SolanaSwapData}
+     * Converts initialize instruction data into {@link SolanaSwapData}.
      *
-     * @param initIx
-     * @param txoHash
-     * @private
-     * @returns {SolanaSwapData} converted and parsed swap data
+     * @param initIx Decoded initialize instruction
+     * @param txoHash Parsed txo hash hint from initialize event
+     * @returns Converted and parsed swap data
      */
     static fromInstruction(
         initIx: InitInstruction,
@@ -421,6 +491,11 @@ export class SolanaSwapData extends SwapData {
         });
     }
 
+    /**
+     * Deserializes swap data from an on-chain escrow account state.
+     *
+     * @param account Escrow account state as returned by Anchor
+     */
     static fromEscrowState(account: IdlAccounts<SwapProgram>["escrowState"]) {
         const data: IdlTypes<SwapProgram>["SwapData"] = account.data;
 
@@ -444,6 +519,11 @@ export class SolanaSwapData extends SwapData {
         });
     }
 
+    /**
+     * Converts abstract swap type to Solana program kind discriminator.
+     *
+     * @param type Chain-agnostic swap type
+     */
     static typeToKind(type: ChainSwapType): number {
         switch (type) {
             case ChainSwapType.HTLC:
@@ -457,6 +537,11 @@ export class SolanaSwapData extends SwapData {
         }
     }
 
+    /**
+     * Converts Solana program kind discriminator to abstract swap type.
+     *
+     * @param value Solana program swap kind value
+     */
     static kindToType(value: number): ChainSwapType {
         switch(value) {
             case 0:

--- a/src/solana/swaps/SolanaSwapProgram.ts
+++ b/src/solana/swaps/SolanaSwapProgram.ts
@@ -110,11 +110,11 @@ export class SolanaSwapProgram
     /**
      * Grace period (seconds) applied to claimer-side expiry checks.
      */
-    readonly claimGracePeriod: number = 10*60;
+    private readonly claimGracePeriod: number = 10*60;
     /**
      * Grace period (seconds) applied to offerer-side expiry checks.
      */
-    readonly refundGracePeriod: number = 10*60;
+    private readonly refundGracePeriod: number = 10*60;
     /**
      * Authorization grace period in seconds.
      */

--- a/src/solana/swaps/SolanaSwapProgram.ts
+++ b/src/solana/swaps/SolanaSwapProgram.ts
@@ -46,6 +46,8 @@ function toPublicKeyOrNull(str: string | null | undefined): PublicKey | undefine
 const MAX_PARALLEL_COMMIT_STATUS_CHECKS = 5;
 
 /**
+ * Solana swap (escrow manager) program representation handling PrTLC (on-chain) and HTLC (lightning) based swaps.
+ *
  * @category Swaps
  */
 export class SolanaSwapProgram
@@ -61,33 +63,84 @@ export class SolanaSwapProgram
 
     ////////////////////////
     //// Constants
+    /**
+     * Rent-exempt amount (lamports) for escrow state accounts.
+     */
     public readonly ESCROW_STATE_RENT_EXEMPT = 2658720;
 
     ////////////////////////
     //// PDA accessors
+    /**
+     * PDA of the swap vault authority.
+     */
     readonly SwapVaultAuthority = this.pda("authority");
+    /**
+     * PDA helper for global token vault accounts.
+     */
     readonly SwapVault = this.pda("vault", (tokenAddress: PublicKey) => [tokenAddress.toBuffer()]);
+    /**
+     * PDA helper for per-user token vault accounts.
+     */
     readonly SwapUserVault = this.pda("uservault",
         (publicKey: PublicKey, tokenAddress: PublicKey) => [publicKey.toBuffer(), tokenAddress.toBuffer()]
     );
+    /**
+     * PDA helper for escrow state accounts.
+     */
     readonly SwapEscrowState = this.pda("state", (hash: Buffer) => [hash]);
 
     ////////////////////////
     //// Timeouts
+    /**
+     * @inheritDoc
+     */
     readonly chainId: "SOLANA" = "SOLANA";
+    /**
+     * @inheritDoc
+     */
     readonly claimWithSecretTimeout: number = 45;
+    /**
+     * @inheritDoc
+     */
     readonly claimWithTxDataTimeout: number = 120;
+    /**
+     * @inheritDoc
+     */
     readonly refundTimeout: number = 45;
+    /**
+     * Grace period (seconds) applied to claimer-side expiry checks.
+     */
     readonly claimGracePeriod: number = 10*60;
+    /**
+     * Grace period (seconds) applied to offerer-side expiry checks.
+     */
     readonly refundGracePeriod: number = 10*60;
+    /**
+     * Authorization grace period in seconds.
+     */
     readonly authGracePeriod: number = 5*60;
 
     ////////////////////////
     //// Services
+    /**
+     * Swap initialization service.
+     */
     readonly Init: SwapInit;
+    /**
+     * Swap refund service.
+     */
     readonly Refund: SwapRefund;
+    /**
+     * Swap claim service.
+     */
     readonly Claim: SwapClaim;
+    /**
+     * Temporary data-account lifecycle service.
+     */
     readonly DataAccount: SolanaDataAccount;
+    /**
+     * LP vault interaction service.
+     */
     readonly LpVault: SolanaLpVault;
 
     constructor(
@@ -626,6 +679,12 @@ export class SolanaSwapProgram
         return this.LpVault.getIntermediaryReputation(new PublicKey(address), new PublicKey(token));
     }
 
+    /**
+     * Returns intermediary vault balance for a specific token.
+     *
+     * @param address Intermediary address
+     * @param token Token mint
+     */
     getIntermediaryBalance(address: PublicKey, token: PublicKey): Promise<bigint> {
         return this.LpVault.getIntermediaryBalance(address, token);
     }

--- a/src/solana/swaps/SolanaSwapProgram.ts
+++ b/src/solana/swaps/SolanaSwapProgram.ts
@@ -72,22 +72,26 @@ export class SolanaSwapProgram
     //// PDA accessors
     /**
      * PDA of the swap vault authority.
+     * @internal
      */
-    readonly SwapVaultAuthority = this.pda("authority");
+    readonly _SwapVaultAuthority = this.pda("authority");
     /**
      * PDA helper for global token vault accounts.
+     * @internal
      */
-    readonly SwapVault = this.pda("vault", (tokenAddress: PublicKey) => [tokenAddress.toBuffer()]);
+    readonly _SwapVault = this.pda("vault", (tokenAddress: PublicKey) => [tokenAddress.toBuffer()]);
     /**
      * PDA helper for per-user token vault accounts.
+     * @internal
      */
-    readonly SwapUserVault = this.pda("uservault",
+    readonly _SwapUserVault = this.pda("uservault",
         (publicKey: PublicKey, tokenAddress: PublicKey) => [publicKey.toBuffer(), tokenAddress.toBuffer()]
     );
     /**
      * PDA helper for escrow state accounts.
+     * @internal
      */
-    readonly SwapEscrowState = this.pda("state", (hash: Buffer) => [hash]);
+    readonly _SwapEscrowState = this.pda("state", (hash: Buffer) => [hash]);
 
     ////////////////////////
     //// Timeouts
@@ -117,31 +121,33 @@ export class SolanaSwapProgram
     private readonly refundGracePeriod: number = 10*60;
     /**
      * Authorization grace period in seconds.
+     * @internal
      */
-    readonly authGracePeriod: number = 5*60;
+    readonly _authGracePeriod: number = 5*60;
 
     ////////////////////////
     //// Services
     /**
      * Swap initialization service.
      */
-    readonly Init: SwapInit;
+    private readonly Init: SwapInit;
     /**
      * Swap refund service.
      */
-    readonly Refund: SwapRefund;
+    private readonly Refund: SwapRefund;
     /**
      * Swap claim service.
      */
-    readonly Claim: SwapClaim;
-    /**
-     * Temporary data-account lifecycle service.
-     */
-    readonly DataAccount: SolanaDataAccount;
+    private readonly Claim: SwapClaim;
     /**
      * LP vault interaction service.
      */
-    readonly LpVault: SolanaLpVault;
+    private readonly LpVault: SolanaLpVault;
+    /**
+     * Temporary data-account lifecycle service.
+     * @internal
+     */
+    readonly _DataAccount: SolanaDataAccount;
 
     constructor(
         chainInterface: SolanaChainInterface,
@@ -154,7 +160,7 @@ export class SolanaSwapProgram
         this.Init = new SwapInit(chainInterface, this);
         this.Refund = new SwapRefund(chainInterface, this);
         this.Claim = new SwapClaim(chainInterface, this, btcRelay);
-        this.DataAccount = new SolanaDataAccount(chainInterface, this, storage);
+        this._DataAccount = new SolanaDataAccount(chainInterface, this, storage);
         this.LpVault = new SolanaLpVault(chainInterface, this);
     }
 
@@ -162,21 +168,21 @@ export class SolanaSwapProgram
      * @inheritDoc
      */
     async start(): Promise<void> {
-        await this.DataAccount.init();
+        await this._DataAccount.init();
     }
 
     /**
      * @inheritDoc
      */
     getClaimableDeposits(signer: string): Promise<{count: number, totalValue: bigint}> {
-        return this.DataAccount.getDataAccountsInfo(new PublicKey(signer));
+        return this._DataAccount.getDataAccountsInfo(new PublicKey(signer));
     }
 
     /**
      * @inheritDoc
      */
     claimDeposits(signer: SolanaSigner): Promise<{txIds: string[], count: number, totalValue: bigint}> {
-        return this.DataAccount.sweepDataAccounts(signer);
+        return this._DataAccount.sweepDataAccounts(signer);
     }
 
     ////////////////////////////////////////////
@@ -241,14 +247,14 @@ export class SolanaSwapProgram
      * @inheritDoc
      */
     getDataSignature(signer: SolanaSigner, data: Buffer): Promise<string> {
-        return this.Chain.Signatures.getDataSignature(signer, data);
+        return this._Chain.Signatures.getDataSignature(signer, data);
     }
 
     /**
      * @inheritDoc
      */
     isValidDataSignature(data: Buffer, signature: string, publicKey: string): Promise<boolean> {
-        return this.Chain.Signatures.isValidDataSignature(data, signature, publicKey);
+        return this._Chain.Signatures.isValidDataSignature(data, signature, publicKey);
     }
 
     ////////////////////////////////////////////
@@ -268,7 +274,7 @@ export class SolanaSwapProgram
     async isCommited(swapData: SolanaSwapData): Promise<boolean> {
         const paymentHash = Buffer.from(swapData.paymentHash, "hex");
 
-        const account = await this.program.account.escrowState.fetchNullable(this.SwapEscrowState(paymentHash));
+        const account = await this.program.account.escrowState.fetchNullable(this._SwapEscrowState(paymentHash));
         if(account==null) return false;
 
         return swapData.correctPDA(account);
@@ -335,7 +341,7 @@ export class SolanaSwapProgram
      * @inheritDoc
      */
     async getCommitStatus(signer: string, data: SolanaSwapData): Promise<SwapCommitState> {
-        const escrowStateKey = this.SwapEscrowState(Buffer.from(data.paymentHash, "hex"));
+        const escrowStateKey = this._SwapEscrowState(Buffer.from(data.paymentHash, "hex"));
         const [escrowState, isExpired] = await Promise.all([
             this.program.account.escrowState.fetchNullable(escrowStateKey) as Promise<IdlAccounts<SwapProgram>["escrowState"]>,
             this.isExpired(signer,data)
@@ -352,7 +358,7 @@ export class SolanaSwapProgram
         }
 
         //Check if paid or what
-        const status: SwapNotCommitedState | SwapExpiredState | SwapPaidState | null = await this.Events.findInEvents(escrowStateKey, async (event, tx) => {
+        const status: SwapNotCommitedState | SwapExpiredState | SwapPaidState | null = await this._Events.findInEvents(escrowStateKey, async (event, tx) => {
             if(event.name==="ClaimEvent") {
                 const paymentHash = Buffer.from(event.data.hash).toString("hex");
                 if(paymentHash!==data.paymentHash) return null;
@@ -415,11 +421,11 @@ export class SolanaSwapProgram
      */
     async getClaimHashStatus(claimHash: string): Promise<SwapCommitStateType> {
         const {paymentHash} = fromClaimHash(claimHash);
-        const escrowStateKey = this.SwapEscrowState(Buffer.from(paymentHash, "hex"));
+        const escrowStateKey = this._SwapEscrowState(Buffer.from(paymentHash, "hex"));
         const abortController = new AbortController();
 
         //Start fetching events before checking escrow PDA, this call is used when quoting, so saving 100ms here helps a lot!
-        const eventsPromise = this.Events.findInEvents(escrowStateKey, async (event) => {
+        const eventsPromise = this._Events.findInEvents(escrowStateKey, async (event) => {
             if(event.name==="ClaimEvent") return SwapCommitStateType.PAID;
             if(event.name==="RefundEvent") return SwapCommitStateType.NOT_COMMITED;
         }, abortController.signal).catch(e => {
@@ -451,7 +457,7 @@ export class SolanaSwapProgram
 
         const account: IdlAccounts<SwapProgram>["escrowState"] | null =
             await this.program.account.escrowState.fetchNullable(
-                this.SwapEscrowState(paymentHashBuffer)
+                this._SwapEscrowState(paymentHashBuffer)
             );
         if(account==null) return null;
 
@@ -481,7 +487,7 @@ export class SolanaSwapProgram
 
         const events: {event: ProgramEvent<SwapProgram>, tx: ParsedTransactionWithMeta}[] = [];
 
-        await this.Events.findInEvents(new PublicKey(signer), async (event, tx) => {
+        await this._Events.findInEvents(new PublicKey(signer), async (event, tx) => {
             if(latestBlockheight==null) latestBlockheight = tx.slot;
             events.push({event, tx});
         }, undefined, undefined, startBlockheight);
@@ -519,7 +525,7 @@ export class SolanaSwapProgram
             if(event.name==="InitializeEvent") {
                 //Parse swap data from initialize event
                 const txoHash: string = Buffer.from(event.data.txoHash).toString("hex");
-                const instructions = this.Events.decodeInstructions(tx.transaction.message);
+                const instructions = this._Events.decodeInstructions(tx.transaction.message);
                 if(instructions == null) {
                     this.logger.warn(`getHistoricalSwaps(): Skipping tx ${txSignature} because cannot parse instructions!`);
                     continue;
@@ -653,7 +659,7 @@ export class SolanaSwapProgram
      */
     async getBalance(signer: string, tokenAddress: string, inContract: boolean): Promise<bigint> {
         if(!inContract) {
-            return await this.Chain.getBalance(signer, tokenAddress);
+            return await this._Chain.getBalance(signer, tokenAddress);
         }
 
         const token = new PublicKey(tokenAddress);
@@ -785,7 +791,7 @@ export class SolanaSwapProgram
         txOptions?: TransactionConfirmationOptions
     ): Promise<string> {
         const result = await this.Claim.txsClaimWithSecret(signer.getPublicKey(), swapData, secret, checkExpiry, initAta, txOptions?.feeRate);
-        const [signature] = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const [signature] = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
         return signature;
     }
 
@@ -810,8 +816,8 @@ export class SolanaSwapProgram
             commitedHeader, synchronizer, initAta, txOptions?.feeRate
         );
 
-        const signatures = await this.Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal);
-        await this.DataAccount.removeDataAccount(storageAcc);
+        const signatures = await this._Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        await this._DataAccount.removeDataAccount(storageAcc);
 
         return signatures[claimTxIndex] ?? signatures[0];
     }
@@ -828,7 +834,7 @@ export class SolanaSwapProgram
     ): Promise<string> {
         let result = await this.txsRefund(signer.getAddress(), swapData, check, initAta, txOptions?.feeRate);
 
-        const [signature] = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const [signature] = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
 
         return signature;
     }
@@ -846,7 +852,7 @@ export class SolanaSwapProgram
     ): Promise<string> {
         let result = await this.txsRefundWithAuthorization(signer.getAddress(), swapData, signature, check, initAta, txOptions?.feeRate);
 
-        const [txSignature] = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const [txSignature] = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
 
         return txSignature;
     }
@@ -869,7 +875,7 @@ export class SolanaSwapProgram
 
         const result = await this.txsInit(signer.getAddress(), swapData, signature, skipChecks, txOptions?.feeRate);
 
-        const signatures = await this.Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const signatures = await this._Chain.sendAndConfirm(signer, result, txOptions?.waitForConfirmation, txOptions?.abortSignal);
 
         return signatures[signatures.length-1];
     }
@@ -890,7 +896,7 @@ export class SolanaSwapProgram
         const txsCommit = await this.txsInit(signer.getAddress(), swapData, signature, skipChecks, txOptions?.feeRate);
         const txsClaim = await this.Claim.txsClaimWithSecret(signer.getPublicKey(), swapData, secret, true, false, txOptions?.feeRate, true);
 
-        const signatures = await this.Chain.sendAndConfirm(signer, txsCommit.concat(txsClaim), txOptions?.waitForConfirmation, txOptions?.abortSignal);
+        const signatures = await this._Chain.sendAndConfirm(signer, txsCommit.concat(txsClaim), txOptions?.waitForConfirmation, txOptions?.abortSignal);
         return [signatures[txsCommit.length-1], signatures[signatures.length-1]]
     }
 
@@ -904,7 +910,7 @@ export class SolanaSwapProgram
         txOptions?: TransactionConfirmationOptions
     ): Promise<string> {
         const txs = await this.LpVault.txsWithdraw(signer.getPublicKey(), new PublicKey(token), amount, txOptions?.feeRate);
-        const [txId] = await this.Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
+        const [txId] = await this._Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
         return txId;
     }
 
@@ -918,7 +924,7 @@ export class SolanaSwapProgram
         txOptions?: TransactionConfirmationOptions
     ): Promise<string> {
         const txs = await this.LpVault.txsDeposit(signer.getPublicKey(), new PublicKey(token), amount, txOptions?.feeRate);
-        const [txId] = await this.Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
+        const [txId] = await this._Chain.sendAndConfirm(signer, txs, txOptions?.waitForConfirmation, txOptions?.abortSignal, false);
         return txId;
     }
 

--- a/src/solana/swaps/modules/SolanaDataAccount.ts
+++ b/src/solana/swaps/modules/SolanaDataAccount.ts
@@ -37,10 +37,10 @@ export class StoredDataAccount implements StorageObject {
 
 export class SolanaDataAccount extends SolanaSwapModule {
 
-    readonly SwapTxDataAlt = this.program.keypair(
+    readonly SwapTxDataAlt = this.program._keypair(
         (reversedTxId: Buffer, signer: Signer) => [Buffer.from(signer.secretKey), reversedTxId]
     );
-    readonly SwapTxDataAltBuffer = this.program.keypair((reversedTxId: Buffer, secret: Buffer) => [secret, reversedTxId]);
+    readonly SwapTxDataAltBuffer = this.program._keypair((reversedTxId: Buffer, secret: Buffer) => [secret, reversedTxId]);
 
     readonly storage: IStorageManager<StoredDataAccount>;
 

--- a/src/solana/swaps/modules/SolanaLpVault.ts
+++ b/src/solana/swaps/modules/SolanaLpVault.ts
@@ -35,9 +35,9 @@ export class SolanaLpVault extends SolanaSwapModule {
                 .accounts({
                     signer,
                     signerAta: ata,
-                    userData: this.program.SwapUserVault(signer, token),
-                    vault: this.program.SwapVault(token),
-                    vaultAuthority: this.program.SwapVaultAuthority,
+                    userData: this.program._SwapUserVault(signer, token),
+                    vault: this.program._SwapVault(token),
+                    vaultAuthority: this.program._SwapVaultAuthority,
                     mint: token,
                     tokenProgram: TOKEN_PROGRAM_ID
                 })
@@ -62,9 +62,9 @@ export class SolanaLpVault extends SolanaSwapModule {
                 .accounts({
                     signer,
                     signerAta: ata,
-                    userData: this.program.SwapUserVault(signer, token),
-                    vault: this.program.SwapVault(token),
-                    vaultAuthority: this.program.SwapVaultAuthority,
+                    userData: this.program._SwapUserVault(signer, token),
+                    vault: this.program._SwapVault(token),
+                    vaultAuthority: this.program._SwapVaultAuthority,
                     mint: token,
                     systemProgram: SystemProgram.programId,
                     tokenProgram: TOKEN_PROGRAM_ID
@@ -85,7 +85,7 @@ export class SolanaLpVault extends SolanaSwapModule {
         reputation: IntermediaryReputationType
     } | null> {
         const data = await this.swapProgram.account.userAccount.fetchNullable(
-            this.program.SwapUserVault(address, token)
+            this.program._SwapUserVault(address, token)
         );
 
         if(data==null) return null;
@@ -201,8 +201,8 @@ export class SolanaLpVault extends SolanaSwapModule {
         return this.root.Fees.getFeeRate([
             signer,
             ata,
-            this.program.SwapUserVault(signer, token),
-            this.program.SwapVault(token)
+            this.program._SwapUserVault(signer, token),
+            this.program._SwapVault(token)
         ])
     }
 

--- a/src/solana/swaps/modules/SwapClaim.ts
+++ b/src/solana/swaps/modules/SwapClaim.ts
@@ -52,7 +52,7 @@ export class SwapClaim extends SolanaSwapModule {
         const accounts = {
             signer,
             initializer: swapData.isPayIn() ? swapData.offerer : swapData.claimer,
-            escrowState: this.program.SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")),
+            escrowState: this.program._SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")),
             ixSysvar: SYSVAR_INSTRUCTIONS_PUBKEY,
             data: isDataKey ? secretOrDataKey : null,
         };
@@ -67,8 +67,8 @@ export class SwapClaim extends SolanaSwapModule {
                     .accounts({
                         ...accounts,
                         claimerAta: swapData.claimerAta,
-                        vault: this.program.SwapVault(swapData.token),
-                        vaultAuthority: this.program.SwapVaultAuthority,
+                        vault: this.program._SwapVault(swapData.token),
+                        vaultAuthority: this.program._SwapVaultAuthority,
                         tokenProgram: TOKEN_PROGRAM_ID
                     })
                     .instruction(),
@@ -80,7 +80,7 @@ export class SwapClaim extends SolanaSwapModule {
                     .claimerClaim(secretBuffer)
                     .accounts({
                         ...accounts,
-                        claimerUserData: this.program.SwapUserVault(swapData.claimer, swapData.token)
+                        claimerUserData: this.program._SwapUserVault(swapData.claimer, swapData.token)
                     })
                     .instruction(),
                 this.getComputeBudget(swapData)
@@ -210,7 +210,7 @@ export class SwapClaim extends SolanaSwapModule {
         ]);
         this.logger.debug("addTxsWriteTransactionData(): writing transaction data: ", writeData.toString("hex"));
 
-        return this.program.DataAccount.addTxsWriteData(signer, reversedTxId, writeData, txs, feeRate);
+        return this.program._DataAccount.addTxsWriteData(signer, reversedTxId, writeData, txs, feeRate);
     }
 
     /**
@@ -307,7 +307,7 @@ export class SwapClaim extends SolanaSwapModule {
 
         if(feeRate==null) feeRate = await this.getClaimFeeRate(signerKey, swapData);
 
-        const merkleProof = await this.btcRelay.bitcoinRpc.getMerkleProof(tx.txid, tx.blockhash);
+        const merkleProof = await this.btcRelay._bitcoinRpc.getMerkleProof(tx.txid, tx.blockhash);
         if(merkleProof==null) throw new Error(`Failed to generate merkle proof for tx: ${tx.txid}`);
         this.logger.debug("txsClaimWithTxData(): merkle proof computed: ", merkleProof);
 
@@ -340,7 +340,7 @@ export class SwapClaim extends SolanaSwapModule {
     public getClaimFeeRate(signer: PublicKey, swapData: SolanaSwapData): Promise<string> {
         const accounts: PublicKey[] = [signer];
         if(swapData.payOut) {
-            if(swapData.token!=null) accounts.push(this.program.SwapVault(swapData.token));
+            if(swapData.token!=null) accounts.push(this.program._SwapVault(swapData.token));
             if(swapData.payIn) {
                 if(swapData.offerer!=null) accounts.push(swapData.offerer);
             } else {
@@ -348,7 +348,7 @@ export class SwapClaim extends SolanaSwapModule {
             }
             if(swapData.claimerAta!=null && !swapData.claimerAta.equals(PublicKey.default)) accounts.push(swapData.claimerAta);
         } else {
-            if(swapData.claimer!=null && swapData.token!=null) accounts.push(this.program.SwapUserVault(swapData.claimer, swapData.token));
+            if(swapData.claimer!=null && swapData.token!=null) accounts.push(this.program._SwapUserVault(swapData.claimer, swapData.token));
 
             if(swapData.payIn) {
                 if(swapData.offerer!=null) accounts.push(swapData.offerer);
@@ -357,7 +357,7 @@ export class SwapClaim extends SolanaSwapModule {
             }
         }
 
-        if(swapData.paymentHash!=null) accounts.push(this.program.SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")));
+        if(swapData.paymentHash!=null) accounts.push(this.program._SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")));
 
         return this.root.Fees.getFeeRate(accounts);
     }

--- a/src/solana/swaps/modules/SwapInit.ts
+++ b/src/solana/swaps/modules/SwapInit.ts
@@ -59,11 +59,11 @@ export class SwapInit extends SolanaSwapModule {
         const accounts = {
             claimer: swapData.claimer,
             offerer: swapData.offerer,
-            escrowState: this.program.SwapEscrowState(paymentHash),
+            escrowState: this.program._SwapEscrowState(paymentHash),
             mint: swapData.token,
             systemProgram: SystemProgram.programId,
             claimerAta: swapData.payOut ? claimerAta : null,
-            claimerUserData: !swapData.payOut ? this.program.SwapUserVault(swapData.claimer, swapData.token) : null
+            claimerUserData: !swapData.payOut ? this.program._SwapUserVault(swapData.claimer, swapData.token) : null
         };
 
         if(swapData.payIn) {
@@ -79,8 +79,8 @@ export class SwapInit extends SolanaSwapModule {
                     .accounts({
                         ...accounts,
                         offererAta: ata,
-                        vault: this.program.SwapVault(swapData.token),
-                        vaultAuthority: this.program.SwapVaultAuthority,
+                        vault: this.program._SwapVault(swapData.token),
+                        vaultAuthority: this.program._SwapVaultAuthority,
                         tokenProgram: TOKEN_PROGRAM_ID,
                     })
                     .instruction(),
@@ -98,7 +98,7 @@ export class SwapInit extends SolanaSwapModule {
                     )
                     .accounts({
                         ...accounts,
-                        offererUserData: this.program.SwapUserVault(swapData.offerer, swapData.token),
+                        offererUserData: this.program._SwapUserVault(swapData.offerer, swapData.token),
                     })
                     .instruction(),
                 SwapInit.CUCosts.INIT
@@ -374,7 +374,7 @@ export class SwapInit extends SolanaSwapModule {
         if(prefix!==this.getAuthPrefix(swapData)) throw new SignatureVerificationError("Invalid prefix");
 
         const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
-        const isExpired = (BigInt(timeout) - currentTimestamp) < BigInt(this.program.authGracePeriod);
+        const isExpired = (BigInt(timeout) - currentTimestamp) < BigInt(this.program._authGracePeriod);
         if (isExpired) throw new SignatureVerificationError("Authorization expired!");
 
         const [transactionSlot, signatureString] = signature.split(";");
@@ -425,7 +425,7 @@ export class SwapInit extends SolanaSwapModule {
         const now = Date.now();
 
         const slotExpiryTime = now + (slotsLeft*this.root.SLOT_TIME);
-        const timeoutExpiryTime = (parseInt(timeout)-this.program.authGracePeriod)*1000;
+        const timeoutExpiryTime = (parseInt(timeout)-this.program._authGracePeriod)*1000;
         const expiry = Math.min(slotExpiryTime, timeoutExpiryTime);
 
         if(expiry<now) return 0;
@@ -452,7 +452,7 @@ export class SwapInit extends SolanaSwapModule {
         const slotsLeft = lastValidTransactionSlot-latestSlot+this.SIGNATURE_SLOT_BUFFER;
 
         if(slotsLeft<0) return true;
-        if((parseInt(timeout)+this.program.authGracePeriod)*1000 < Date.now()) return true;
+        if((parseInt(timeout)+this.program._authGracePeriod)*1000 < Date.now()) return true;
         return false;
     }
 
@@ -562,11 +562,11 @@ export class SwapInit extends SolanaSwapModule {
 
         if (offerer != null) accounts.push(offerer);
         if (token != null) {
-            accounts.push(this.program.SwapVault(token));
+            accounts.push(this.program._SwapVault(token));
             if (offerer != null) accounts.push(getAssociatedTokenAddressSync(token, offerer));
-            if (claimer != null) accounts.push(this.program.SwapUserVault(claimer, token));
+            if (claimer != null) accounts.push(this.program._SwapUserVault(claimer, token));
         }
-        if (paymentHash != null) accounts.push(this.program.SwapEscrowState(Buffer.from(paymentHash, "hex")));
+        if (paymentHash != null) accounts.push(this.program._SwapEscrowState(Buffer.from(paymentHash, "hex")));
 
         const shouldCheckWSOLAta = token != null && offerer != null && token.equals(SolanaTokens.WSOL_ADDRESS);
         let [feeRate, account] = await Promise.all([
@@ -597,9 +597,9 @@ export class SwapInit extends SolanaSwapModule {
     public getInitFeeRate(offerer?: PublicKey, claimer?: PublicKey, token?: PublicKey, paymentHash?: string): Promise<string> {
         const accounts: PublicKey[] = [];
 
-        if(offerer!=null && token!=null) accounts.push(this.program.SwapUserVault(offerer, token));
+        if(offerer!=null && token!=null) accounts.push(this.program._SwapUserVault(offerer, token));
         if(claimer!=null) accounts.push(claimer)
-        if(paymentHash!=null) accounts.push(this.program.SwapEscrowState(Buffer.from(paymentHash, "hex")));
+        if(paymentHash!=null) accounts.push(this.program._SwapEscrowState(Buffer.from(paymentHash, "hex")));
 
         return this.root.Fees.getFeeRate(accounts);
     }

--- a/src/solana/swaps/modules/SwapInit.ts
+++ b/src/solana/swaps/modules/SwapInit.ts
@@ -233,7 +233,7 @@ export class SwapInit extends SolanaSwapModule {
             preFetchedData.latestSlot!=null &&
             preFetchedData.latestSlot.timestamp>Date.now()-this.root.Slots.SLOT_CACHE_TIME
         ) {
-            const estimatedSlotsPassed = Math.floor((Date.now()-preFetchedData.latestSlot.timestamp)/this.root.SLOT_TIME);
+            const estimatedSlotsPassed = Math.floor((Date.now()-preFetchedData.latestSlot.timestamp)/this.root._SLOT_TIME);
             const estimatedCurrentSlot = preFetchedData.latestSlot.slot+estimatedSlotsPassed;
             this.logger.debug("getSlotForSignature(): slot: "+preFetchedData.latestSlot.slot+
                 " estimated passed slots: "+estimatedSlotsPassed+" estimated current slot: "+estimatedCurrentSlot);
@@ -385,7 +385,7 @@ export class SwapInit extends SolanaSwapModule {
             this.getBlockhashForSignature(txSlot, preFetchedData)
         ]);
 
-        const lastValidTransactionSlot = txSlot+this.root.TX_SLOT_VALIDITY;
+        const lastValidTransactionSlot = txSlot+this.root._TX_SLOT_VALIDITY;
         const slotsLeft = lastValidTransactionSlot-latestSlot-this.SIGNATURE_SLOT_BUFFER;
         if(slotsLeft<0) throw new SignatureVerificationError("Authorization expired!");
 
@@ -419,12 +419,12 @@ export class SwapInit extends SolanaSwapModule {
         const txSlot = parseInt(transactionSlotStr);
 
         const latestSlot = await this.getSlotForSignature(preFetchedData);
-        const lastValidTransactionSlot = txSlot+this.root.TX_SLOT_VALIDITY;
+        const lastValidTransactionSlot = txSlot+this.root._TX_SLOT_VALIDITY;
         const slotsLeft = lastValidTransactionSlot-latestSlot-this.SIGNATURE_SLOT_BUFFER;
 
         const now = Date.now();
 
-        const slotExpiryTime = now + (slotsLeft*this.root.SLOT_TIME);
+        const slotExpiryTime = now + (slotsLeft*this.root._SLOT_TIME);
         const timeoutExpiryTime = (parseInt(timeout)-this.program._authGracePeriod)*1000;
         const expiry = Math.min(slotExpiryTime, timeoutExpiryTime);
 
@@ -447,7 +447,7 @@ export class SwapInit extends SolanaSwapModule {
         const [transactionSlotStr, signatureString] = signature.split(";");
         const txSlot = parseInt(transactionSlotStr);
 
-        const lastValidTransactionSlot = txSlot+this.root.TX_SLOT_VALIDITY;
+        const lastValidTransactionSlot = txSlot+this.root._TX_SLOT_VALIDITY;
         const latestSlot = await this.root.Slots.getSlot("finalized");
         const slotsLeft = lastValidTransactionSlot-latestSlot+this.SIGNATURE_SLOT_BUFFER;
 

--- a/src/solana/swaps/modules/SwapRefund.ts
+++ b/src/solana/swaps/modules/SwapRefund.ts
@@ -38,8 +38,8 @@ export class SwapRefund extends SolanaSwapModule {
         const accounts = {
             offerer: swapData.offerer,
             claimer: swapData.claimer,
-            escrowState: this.program.SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")),
-            claimerUserData: !swapData.payOut ? this.program.SwapUserVault(swapData.claimer, swapData.token) : null,
+            escrowState: this.program._SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")),
+            claimerUserData: !swapData.payOut ? this.program._SwapUserVault(swapData.claimer, swapData.token) : null,
             ixSysvar: refundAuthTimeout!=null ? SYSVAR_INSTRUCTIONS_PUBKEY : null
         };
 
@@ -53,8 +53,8 @@ export class SwapRefund extends SolanaSwapModule {
                     .accounts({
                         ...accounts,
                         offererAta: ata,
-                        vault: this.program.SwapVault(swapData.token),
-                        vaultAuthority: this.program.SwapVaultAuthority,
+                        vault: this.program._SwapVault(swapData.token),
+                        vaultAuthority: this.program._SwapVaultAuthority,
                         tokenProgram: TOKEN_PROGRAM_ID
                     })
                     .instruction(),
@@ -66,7 +66,7 @@ export class SwapRefund extends SolanaSwapModule {
                     .offererRefund(toBN(useTimeout))
                     .accounts({
                         ...accounts,
-                        offererUserData: this.program.SwapUserVault(swapData.offerer, swapData.token)
+                        offererUserData: this.program._SwapUserVault(swapData.offerer, swapData.token)
                     })
                     .instruction(),
                 SwapRefund.CUCosts.REFUND
@@ -164,7 +164,7 @@ export class SwapRefund extends SolanaSwapModule {
         const expiryTimestamp = BigInt(timeout);
         const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
 
-        const isExpired = (expiryTimestamp - currentTimestamp) < BigInt(this.program.authGracePeriod);
+        const isExpired = (expiryTimestamp - currentTimestamp) < BigInt(this.program._authGracePeriod);
         if(isExpired) throw new SignatureVerificationError("Authorization expired!");
 
         const signatureBuffer = Buffer.from(signature, "hex");
@@ -294,19 +294,19 @@ export class SwapRefund extends SolanaSwapModule {
     public getRefundFeeRate(swapData: SolanaSwapData): Promise<string> {
         const accounts: PublicKey[] = [];
         if(swapData.payIn) {
-            if(swapData.token!=null) accounts.push(this.program.SwapVault(swapData.token));
+            if(swapData.token!=null) accounts.push(this.program._SwapVault(swapData.token));
             if(swapData.offerer!=null) accounts.push(swapData.offerer);
             if(swapData.claimer!=null) accounts.push(swapData.claimer);
             if(swapData.offererAta!=null && !swapData.offererAta.equals(PublicKey.default)) accounts.push(swapData.offererAta);
         } else {
             if(swapData.offerer!=null) {
                 accounts.push(swapData.offerer);
-                if(swapData.token!=null) accounts.push(this.program.SwapUserVault(swapData.offerer, swapData.token));
+                if(swapData.token!=null) accounts.push(this.program._SwapUserVault(swapData.offerer, swapData.token));
             }
             if(swapData.claimer!=null) accounts.push(swapData.claimer);
         }
 
-        if(swapData.paymentHash!=null) accounts.push(this.program.SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")));
+        if(swapData.paymentHash!=null) accounts.push(this.program._SwapEscrowState(Buffer.from(swapData.paymentHash, "hex")));
 
         return this.root.Fees.getFeeRate(accounts);
     }

--- a/src/solana/wallet/SolanaKeypairWallet.ts
+++ b/src/solana/wallet/SolanaKeypairWallet.ts
@@ -7,16 +7,27 @@ import {Keypair, PublicKey, Transaction, VersionedTransaction} from "@solana/web
  */
 export class SolanaKeypairWallet implements Wallet {
 
+    /**
+     * Underlying signer keypair.
+     */
     readonly payer: Keypair;
 
     constructor(payer: Keypair) {
         this.payer = payer;
     }
 
+    /**
+     * Public key of the wrapped payer keypair.
+     */
     get publicKey(): PublicKey {
         return this.payer.publicKey;
     }
 
+    /**
+     * Signs all provided transactions with the wrapped keypair.
+     *
+     * @param txs Transactions to sign
+     */
     signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]> {
         txs.forEach((tx) => {
             if(tx instanceof Transaction) {
@@ -28,6 +39,11 @@ export class SolanaKeypairWallet implements Wallet {
         return Promise.resolve(txs);
     }
 
+    /**
+     * Signs a single transaction with the wrapped keypair.
+     *
+     * @param tx Transaction to sign
+     */
     signTransaction<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {
         if(tx instanceof Transaction) {
             tx.partialSign(this.payer);

--- a/src/solana/wallet/SolanaSigner.ts
+++ b/src/solana/wallet/SolanaSigner.ts
@@ -7,9 +7,18 @@ import {PublicKey, Signer} from "@solana/web3.js";
  * @category Wallets
  */
 export class SolanaSigner implements AbstractSigner {
+    /**
+     * @inheritDoc
+     */
     type = "AtomiqAbstractSigner" as const;
 
+    /**
+     * Wrapped wallet implementation used for signing.
+     */
     wallet: Wallet;
+    /**
+     * Optional raw keypair signer when available.
+     */
     keypair?: Signer;
 
     constructor(wallet: Wallet, keypair?: Signer) {
@@ -17,6 +26,9 @@ export class SolanaSigner implements AbstractSigner {
         this.keypair = keypair;
     }
 
+    /**
+     * Returns public key of the wrapped wallet.
+     */
     getPublicKey(): PublicKey {
         return this.wallet.publicKey;
     }


### PR DESCRIPTION
- ConnectionWithRetries wrapper which automatically retries on RPC failures
- Add typedoc coverage
- Private/internalize class members
- Bump bn.js dependency
- README.md and `@packageDoc` in index.ts
- Add a node-only `/node` export shim